### PR TITLE
refactor(ledger): introduce LedgerPort seam (phase 1 of #6)

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -16,6 +16,8 @@ import { routes } from './app.routes';
 import { provideServiceWorker } from '@angular/service-worker';
 import { environment } from '../environments/environment';
 import { provideTranslocoConfig } from './i18n/transloco.providers';
+import { LEDGER_PORT } from './ledger/ports/ledger.port';
+import { FirebaseService } from './services/firebase.service';
 
 /**
  * Only provide Firebase Messaging when the browser supports the required APIs
@@ -59,5 +61,9 @@ export const appConfig: ApplicationConfig = {
     // skipped and this handler silently passes through — no user-visible
     // difference from the default Angular handler.
     { provide: ErrorHandler, useValue: Sentry.createErrorHandler() },
+    // Phase 1 of the LedgerStore refactor (issue #6): expose FirebaseService
+    // through the LEDGER_PORT injection token so future consumers and tests
+    // can bind to the port without touching the concrete service.
+    { provide: LEDGER_PORT, useExisting: FirebaseService },
   ],
 };

--- a/src/app/ledger/infrastructure/in-memory-ledger.adapter.spec.ts
+++ b/src/app/ledger/infrastructure/in-memory-ledger.adapter.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { LEDGER_PORT, LedgerPort } from '../ports/ledger.port';
+import { InMemoryLedgerAdapter } from './in-memory-ledger.adapter';
+import type { ProfileFields } from '../../services/firebase.service';
+
+/**
+ * Contract tests for LedgerPort against the in-memory adapter. When the
+ * Firestore adapter comes online as a separate implementation, these same
+ * cases should run against it via describe.each or the emulator.
+ */
+describe('InMemoryLedgerAdapter (LedgerPort contract)', () => {
+  let port: LedgerPort;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        InMemoryLedgerAdapter,
+        { provide: LEDGER_PORT, useExisting: InMemoryLedgerAdapter },
+      ],
+    });
+    port = TestBed.inject(LEDGER_PORT);
+  });
+
+  describe('profile lifecycle', () => {
+    it('creates a profile on first ensureUserProfile()', async () => {
+      expect(port.profile()).toBeNull();
+      expect(port.profileCompleted()).toBe(false);
+
+      await port.ensureUserProfile();
+
+      expect(port.profile()).not.toBeNull();
+      expect(port.profileCompleted()).toBe(false);
+    });
+
+    it('flips profileCompleted after saveProfile', async () => {
+      await port.ensureUserProfile();
+      const fields: ProfileFields = {
+        heightIn: 70,
+        age: 30,
+        sex: 'male',
+        activityLevel: 'moderate',
+        targetPaceLbsPerWeek: 1.0,
+      };
+      await port.saveProfile(fields);
+
+      expect(port.profileCompleted()).toBe(true);
+      expect(port.profile()?.heightIn).toBe(70);
+    });
+
+    it('clearProfile drops the signal', async () => {
+      await port.ensureUserProfile();
+      port.clearProfile();
+      expect(port.profile()).toBeNull();
+    });
+  });
+
+  describe('daily logs', () => {
+    it('returns logs oldest-first from getRecentLogs', async () => {
+      const t1 = new Date('2026-04-20T08:00:00Z');
+      const t2 = new Date('2026-04-21T08:00:00Z');
+      const t3 = new Date('2026-04-22T08:00:00Z');
+      await port.addLog({ calories: 100, timestamp: t2 });
+      await port.addLog({ calories: 200, timestamp: t1 });
+      await port.addLog({ calories: 300, timestamp: t3 });
+
+      const logs = await port.getRecentLogs(14);
+      expect(logs.map((l) => l.calories)).toEqual([200, 100, 300]);
+    });
+
+    it('respects the days cap', async () => {
+      for (let i = 0; i < 20; i++) {
+        await port.addLog({ calories: i, timestamp: new Date(2026, 3, i + 1) });
+      }
+      const logs = await port.getRecentLogs(5);
+      expect(logs.length).toBe(5);
+    });
+
+    it('updateLog mutates the entry and deleteLog removes it', async () => {
+      await port.addLog({ calories: 100, timestamp: new Date('2026-04-22') });
+      const [entry] = await port.getRecentLogs();
+      await port.updateLog(entry.id!, { calories: 250 });
+      expect((await port.getRecentLogs())[0].calories).toBe(250);
+
+      await port.deleteLog(entry.id!);
+      expect(await port.getRecentLogs()).toEqual([]);
+    });
+  });
+
+  describe('dailyWater clamping', () => {
+    it('clamps input to [0, 20000] and rounds', async () => {
+      await port.setDailyWater('2026-04-22', 999999);
+      await port.setDailyWater('2026-04-21', -50);
+      await port.setDailyWater('2026-04-20', 123.7);
+      const water = await port.getDailyWater();
+      expect(water['2026-04-22']).toBe(20000);
+      expect(water['2026-04-21']).toBe(0);
+      expect(water['2026-04-20']).toBe(124);
+    });
+  });
+
+  describe('presets + measurements', () => {
+    it('round-trips presets', async () => {
+      await port.addPreset({ name: 'Oatmeal', calories: 300, protein: 10 });
+      await port.addPreset({ name: 'Eggs', calories: 140 });
+      const presets = await port.getPresets();
+      expect(presets.length).toBe(2);
+      await port.deletePreset(presets[0].id!);
+      expect((await port.getPresets()).length).toBe(1);
+    });
+
+    it('measurements return newest-first', async () => {
+      await port.addMeasurement({ waist: 34 });
+      await new Promise((r) => setTimeout(r, 2));
+      await port.addMeasurement({ waist: 33 });
+      const ms = await port.getRecentMeasurements();
+      expect(ms[0].waist).toBe(33);
+    });
+  });
+});

--- a/src/app/ledger/infrastructure/in-memory-ledger.adapter.ts
+++ b/src/app/ledger/infrastructure/in-memory-ledger.adapter.ts
@@ -1,0 +1,246 @@
+import { Injectable, computed, signal } from '@angular/core';
+import { Timestamp } from '@angular/fire/firestore';
+import type { LedgerPort } from '../ports/ledger.port';
+import type {
+  DailyLog,
+  LogEntry,
+  MealPreset,
+  Measurement,
+  ProfileFields,
+  UserProfile,
+  WeeklyReport,
+} from '../../services/firebase.service';
+
+/**
+ * In-memory LedgerPort for tests and Storybook. Mirrors FirebaseService
+ * behavior closely enough to satisfy the port contract: insertion-ordered
+ * logs, newest-first ordering on read with oldest-first return for
+ * getRecentLogs (matching the prod service), Timestamp.fromDate for
+ * profile fields that prod stores as Timestamps.
+ *
+ * Deliberately NOT providedIn 'root' — tests opt in via TestBed providers.
+ */
+@Injectable()
+export class InMemoryLedgerAdapter implements LedgerPort {
+  private readonly _profile = signal<UserProfile | null>(null);
+  readonly profile = this._profile.asReadonly();
+  readonly profileCompleted = computed(
+    () => this._profile()?.profileCompleted === true,
+  );
+
+  private readonly logs = new Map<string, DailyLog>();
+  private logSeq = 0;
+  private readonly presets = new Map<string, MealPreset>();
+  private presetSeq = 0;
+  private readonly measurements = new Map<string, Measurement>();
+  private measurementSeq = 0;
+  private readonly weights: Record<string, number> = {};
+  private readonly water: Record<string, number> = {};
+  private report: WeeklyReport | null = null;
+
+  /** Test hook: simulate a signed-in user with no profile doc yet. */
+  setAuthenticatedUser(email: string): void {
+    // no-op in-memory — ensureUserProfile drives the real lifecycle
+    void email;
+  }
+
+  /** Test hook: pre-seed a weekly report (prod writes are server-only). */
+  seedLatestReport(report: WeeklyReport | null): void {
+    this.report = report;
+  }
+
+  async ensureUserProfile(): Promise<void> {
+    if (this._profile()) return;
+    const now = Timestamp.now();
+    this._profile.set({
+      email: 'test@example.com',
+      createdAt: now,
+      lastSeenAt: now,
+      profileCompleted: false,
+    });
+  }
+
+  clearProfile(): void {
+    this._profile.set(null);
+  }
+
+  async saveProfile(fields: ProfileFields): Promise<void> {
+    const current = this._profile();
+    if (!current) throw new Error('No profile loaded.');
+    const patch: Partial<UserProfile> = {
+      heightIn: fields.heightIn,
+      age: fields.age,
+      sex: fields.sex,
+      activityLevel: fields.activityLevel,
+      targetPaceLbsPerWeek: fields.targetPaceLbsPerWeek,
+      profileCompleted: true,
+      lastSeenAt: Timestamp.now(),
+    };
+    if (fields.goalWeightLbs != null) patch.goalWeightLbs = fields.goalWeightLbs;
+    if (fields.ageConfirmed === true && current.ageConfirmedAt == null) {
+      patch.ageConfirmedAt = Timestamp.now();
+    }
+    if (fields.preferredLocale) patch.preferredLocale = fields.preferredLocale;
+    this._profile.set({ ...current, ...patch } as UserProfile);
+  }
+
+  async generateWebhookApiKey(): Promise<string> {
+    const key = crypto.randomUUID();
+    this.patchProfile({ webhookApiKey: key });
+    return key;
+  }
+
+  async revokeWebhookApiKey(): Promise<void> {
+    this.patchProfile({ webhookApiKey: undefined }, ['webhookApiKey']);
+  }
+
+  async saveFcmToken(token: string): Promise<void> {
+    this.patchProfile({
+      fcmToken: token,
+      timezoneOffsetMin: new Date().getTimezoneOffset(),
+    });
+  }
+
+  async clearFcmToken(): Promise<void> {
+    this.patchProfile({}, ['fcmToken']);
+  }
+
+  async saveReminderHour(hour: number): Promise<void> {
+    this.patchProfile({ reminderHour: hour });
+  }
+
+  async startFast(startedAt?: Date): Promise<void> {
+    const start = startedAt ?? new Date();
+    this.patchProfile({ fastStartedAt: start });
+  }
+
+  async breakFast(): Promise<void> {
+    this.patchProfile({ fastStartedAt: null });
+  }
+
+  async setTravelMode(on: boolean): Promise<void> {
+    this.patchProfile({ travelMode: on });
+  }
+
+  async deleteMyAccount(): Promise<void> {
+    this.logs.clear();
+    this.presets.clear();
+    this.measurements.clear();
+    for (const k of Object.keys(this.weights)) delete this.weights[k];
+    for (const k of Object.keys(this.water)) delete this.water[k];
+    this.report = null;
+    this._profile.set(null);
+  }
+
+  async exportMyData(): Promise<unknown> {
+    return {
+      profile: this._profile(),
+      logs: [...this.logs.values()],
+      presets: [...this.presets.values()],
+      measurements: [...this.measurements.values()],
+      dailyWeights: { ...this.weights },
+      dailyWater: { ...this.water },
+      reports: this.report ? [this.report] : [],
+    };
+  }
+
+  async addLog(entry: LogEntry): Promise<void> {
+    const id = `log-${++this.logSeq}`;
+    this.logs.set(id, {
+      id,
+      calories: entry.calories,
+      date: entry.timestamp ?? new Date(),
+      weight: entry.weight,
+      protein: entry.protein,
+      exerciseCompleted: entry.exerciseCompleted || undefined,
+      mealLabel: entry.mealLabel,
+    });
+  }
+
+  async getRecentLogs(days = 14): Promise<DailyLog[]> {
+    // Mirror prod: sort desc by date, take `days` rows, return oldest-first.
+    const sorted = [...this.logs.values()].sort(
+      (a, b) => b.date.getTime() - a.date.getTime(),
+    );
+    return sorted.slice(0, days).reverse();
+  }
+
+  async updateLog(logId: string, entry: LogEntry): Promise<void> {
+    const existing = this.logs.get(logId);
+    if (!existing) return;
+    this.logs.set(logId, {
+      ...existing,
+      calories: entry.calories,
+      protein: entry.protein ?? undefined,
+      exerciseCompleted: entry.exerciseCompleted ? true : undefined,
+      mealLabel: entry.mealLabel ?? undefined,
+      weight: entry.weight ?? existing.weight,
+      date: entry.timestamp ?? existing.date,
+      liftCompleted: undefined,
+      cardioCompleted: undefined,
+    });
+  }
+
+  async deleteLog(logId: string): Promise<void> {
+    this.logs.delete(logId);
+  }
+
+  async getDailyWeights(): Promise<Record<string, number>> {
+    return { ...this.weights };
+  }
+
+  async setDailyWeight(dateKey: string, weight: number): Promise<void> {
+    this.weights[dateKey] = weight;
+  }
+
+  async getDailyWater(): Promise<Record<string, number>> {
+    return { ...this.water };
+  }
+
+  async setDailyWater(dateKey: string, ml: number): Promise<void> {
+    this.water[dateKey] = Math.max(0, Math.min(20000, Math.round(ml)));
+  }
+
+  async getPresets(): Promise<MealPreset[]> {
+    return [...this.presets.values()];
+  }
+
+  async addPreset(preset: Omit<MealPreset, 'id'>): Promise<void> {
+    const id = `preset-${++this.presetSeq}`;
+    this.presets.set(id, { id, ...preset });
+  }
+
+  async deletePreset(presetId: string): Promise<void> {
+    this.presets.delete(presetId);
+  }
+
+  async getLatestReport(): Promise<WeeklyReport | null> {
+    return this.report;
+  }
+
+  async getRecentMeasurements(count = 10): Promise<Measurement[]> {
+    return [...this.measurements.values()]
+      .sort((a, b) => b.date.getTime() - a.date.getTime())
+      .slice(0, count);
+  }
+
+  async addMeasurement(entry: Omit<Measurement, 'id' | 'date'>): Promise<void> {
+    const id = `m-${++this.measurementSeq}`;
+    this.measurements.set(id, { id, date: new Date(), ...entry });
+  }
+
+  async deleteMeasurement(id: string): Promise<void> {
+    this.measurements.delete(id);
+  }
+
+  private patchProfile(
+    patch: Partial<UserProfile>,
+    deleteKeys: ReadonlyArray<keyof UserProfile> = [],
+  ): void {
+    const current = this._profile();
+    if (!current) return;
+    const next = { ...current, ...patch } as UserProfile;
+    for (const k of deleteKeys) delete (next as unknown as Record<string, unknown>)[k as string];
+    this._profile.set(next);
+  }
+}

--- a/src/app/ledger/ports/ledger.port.ts
+++ b/src/app/ledger/ports/ledger.port.ts
@@ -1,0 +1,64 @@
+import { InjectionToken, Signal } from '@angular/core';
+import type {
+  DailyLog,
+  LogEntry,
+  MealPreset,
+  Measurement,
+  ProfileFields,
+  UserProfile,
+  WeeklyReport,
+} from '../../services/firebase.service';
+
+/**
+ * Persistence seam for user-owned data. Implementations are scoped
+ * to the currently signed-in user — the adapter resolves UID from
+ * its own auth context; callers never pass one.
+ *
+ * Phase 1: signatures mirror FirebaseService 1:1 so the existing
+ * service implements this port with no behavior change. Follow-up
+ * phases narrow the surface (explicit UID, Result<T>, domain-typed
+ * drafts without Firestore Timestamp) — see issue #6.
+ */
+export interface LedgerPort {
+  readonly profile: Signal<UserProfile | null>;
+  readonly profileCompleted: Signal<boolean>;
+
+  ensureUserProfile(): Promise<void>;
+  clearProfile(): void;
+  saveProfile(fields: ProfileFields): Promise<void>;
+
+  generateWebhookApiKey(): Promise<string>;
+  revokeWebhookApiKey(): Promise<void>;
+  saveFcmToken(token: string): Promise<void>;
+  clearFcmToken(): Promise<void>;
+  saveReminderHour(hour: number): Promise<void>;
+  startFast(startedAt?: Date): Promise<void>;
+  breakFast(): Promise<void>;
+  setTravelMode(on: boolean): Promise<void>;
+
+  deleteMyAccount(): Promise<void>;
+  exportMyData(): Promise<unknown>;
+
+  addLog(entry: LogEntry): Promise<void>;
+  getRecentLogs(days?: number): Promise<DailyLog[]>;
+  updateLog(logId: string, entry: LogEntry): Promise<void>;
+  deleteLog(logId: string): Promise<void>;
+
+  getDailyWeights(): Promise<Record<string, number>>;
+  setDailyWeight(dateKey: string, weight: number): Promise<void>;
+
+  getDailyWater(): Promise<Record<string, number>>;
+  setDailyWater(dateKey: string, ml: number): Promise<void>;
+
+  getPresets(): Promise<MealPreset[]>;
+  addPreset(preset: Omit<MealPreset, 'id'>): Promise<void>;
+  deletePreset(presetId: string): Promise<void>;
+
+  getLatestReport(): Promise<WeeklyReport | null>;
+
+  getRecentMeasurements(count?: number): Promise<Measurement[]>;
+  addMeasurement(entry: Omit<Measurement, 'id' | 'date'>): Promise<void>;
+  deleteMeasurement(id: string): Promise<void>;
+}
+
+export const LEDGER_PORT = new InjectionToken<LedgerPort>('LedgerPort');

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
+import type { LedgerPort } from '../ledger/ports/ledger.port';
 import {
   Firestore,
   collection,
@@ -122,7 +123,7 @@ export interface UserProfile extends Partial<ProfileFields> {
  * unauthenticated — the UI is responsible for gating.
  */
 @Injectable({ providedIn: 'root' })
-export class FirebaseService {
+export class FirebaseService implements LedgerPort {
   private readonly firestore = inject(Firestore);
   private readonly auth = inject(Auth);
   private readonly functions = inject(Functions);


### PR DESCRIPTION
## Summary

Phase 1 of the LedgerStore refactor (#6). Introduces a port seam between `FirebaseService` and everything that depends on it, without any runtime change.

- New `LedgerPort` interface + `LEDGER_PORT` injection token in `src/app/ledger/ports/`.
- `FirebaseService implements LedgerPort` — TypeScript enforces the contract; no behavior change.
- `InMemoryLedgerAdapter` in `src/app/ledger/infrastructure/` for tests and Storybook.
- 12-case contract spec covering profile lifecycle, log ordering + cap, water clamping, presets, measurements.
- `app.config.ts` wires `{ provide: LEDGER_PORT, useExisting: FirebaseService }`.

## Why this shape

The RFC body originally proposed replacing both `FirebaseService` and `FitnessStore` with a single deep `LedgerStore`. After reading `fitness-store.service.ts` (804 LOC) in full, that framing was wrong: FitnessStore owns ~20 computed signals and real business logic (undo timer, budget-crossed effect, `repeatYesterday`/`copyDayToToday`, weekly-report scheduling). Only FirebaseService is genuinely shallow. See the correction comment on #6.

Phase 1 is strictly additive and reversible. Later phases land incrementally:

- **Phase 2:** migrate the 4 components that `inject(FirebaseService)` directly (`app.ts`, `onboarding`, `settings-sheet`, `privacy`).
- **Phase 3:** switch FitnessStore to `inject(LEDGER_PORT)`; now unit-testable against `InMemoryLedgerAdapter`.
- **Phase 4:** remove the `await op; await _load()` idiom; reconcile on write, per-verb.
- **Phase 5:** narrow the port — explicit UID, `Result<T, DomainError>`, domain-typed drafts without Firestore `Timestamp`.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean
- [x] `npx tsc --noEmit -p tsconfig.spec.json` — clean
- [x] `ng build` — 5.54 MB initial total, no errors
- [x] `ng test` — 91 passed / 2 skipped / 0 failed (7 test files, including the new contract spec)
- [ ] Smoke-test signed-in flows against dev Firebase after merge (no behavior change expected; belt-and-braces)

Closes #6 partially (Phase 1 only; #6 stays open to track Phases 2–5).
