### PR TITLE
refactor(ledger): migrate direct FirebaseService callers to LEDGER_PORT (phase 2 of #6)

### DIFF
--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 import { SwUpdate } from '@angular/service-worker';
 import { App } from './app';
 import { AuthService } from './services/auth.service';
-import { FirebaseService } from './services/firebase.service';
+import { LEDGER_PORT } from './ledger/ports/ledger.port';
 import { FitnessStore } from './services/fitness-store.service';
 import { PushNotificationService } from './services/push-notification.service';
 import { Messaging } from '@angular/fire/messaging';
@@ -42,7 +42,7 @@ describe('App', () => {
           },
         },
         {
-          provide: FirebaseService,
+          provide: LEDGER_PORT,
           useValue: {
             profile: signal(null),
             profileCompleted: signal(false),

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -20,7 +20,7 @@ import { SettingsSheetComponent } from './components/settings-sheet/settings-she
 import { MobileTabsComponent, type MobileTab } from './components/mobile-tabs/mobile-tabs.component';
 import { MobileFabComponent } from './components/mobile-fab/mobile-fab.component';
 import { AuthService } from './services/auth.service';
-import { FirebaseService } from './services/firebase.service';
+import { LEDGER_PORT } from './ledger/ports/ledger.port';
 import { FitnessStore } from './services/fitness-store.service';
 import { SubscriptionService } from './services/subscription.service';
 import { ThemeChoice, PRO_THEMES, isProTheme, readStoredTheme, writeStoredTheme } from './utils/theme';
@@ -378,7 +378,7 @@ import { EntryFormManager } from './services/entry-form-manager.service';
 })
 export class App {
   protected readonly auth = inject(AuthService);
-  protected readonly firebase = inject(FirebaseService);
+  protected readonly firebase = inject(LEDGER_PORT);
   protected readonly store = inject(FitnessStore); // triggers lifecycle via constructor effect
   protected readonly subs = inject(SubscriptionService);
   private readonly upsell = inject(UpsellService);

--- a/src/app/components/onboarding/onboarding.component.spec.ts
+++ b/src/app/components/onboarding/onboarding.component.spec.ts
@@ -4,7 +4,7 @@ import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { afterEach, describe, beforeEach, expect, it, vi } from 'vitest';
 import { provideTranslocoConfig } from '../../i18n/transloco.providers';
-import { FirebaseService } from '../../services/firebase.service';
+import { LEDGER_PORT } from '../../ledger/ports/ledger.port';
 import { TranslationService } from '../../services/translation.service';
 import { OnboardingComponent } from './onboarding.component';
 
@@ -28,7 +28,7 @@ describe('OnboardingComponent', () => {
         provideTranslocoConfig(),
         TranslationService,
         {
-          provide: FirebaseService,
+          provide: LEDGER_PORT,
           useValue: {
             profile: signal(null),
             saveProfile,

--- a/src/app/components/onboarding/onboarding.component.ts
+++ b/src/app/components/onboarding/onboarding.component.ts
@@ -2,12 +2,12 @@ import { ChangeDetectionStrategy, Component, computed, effect, inject, input, ou
 import { FormsModule } from '@angular/forms';
 import { TranslocoDirective } from '@jsverse/transloco';
 import {
-  FirebaseService,
   ActivityLevel,
   CutPace,
   ProfileFields,
   Sex,
 } from '../../services/firebase.service';
+import { LEDGER_PORT } from '../../ledger/ports/ledger.port';
 import { TranslationService } from '../../services/translation.service';
 
 type Status = 'idle' | 'saving' | 'error';
@@ -466,7 +466,7 @@ interface OnboardingDraft {
   `],
 })
 export class OnboardingComponent {
-  private readonly firebase = inject(FirebaseService);
+  private readonly firebase = inject(LEDGER_PORT);
   private readonly translation = inject(TranslationService);
 
   /** When true, we're editing an existing profile rather than creating one. */

--- a/src/app/components/privacy/privacy.component.ts
+++ b/src/app/components/privacy/privacy.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { TranslocoDirective } from '@jsverse/transloco';
 import { AuthService } from '../../services/auth.service';
-import { FirebaseService } from '../../services/firebase.service';
+import { LEDGER_PORT } from '../../ledger/ports/ledger.port';
 import { TranslationService } from '../../services/translation.service';
 import { extractErrorCode } from '../../models/error-codes';
 
@@ -157,7 +157,7 @@ type DeleteStatus = 'idle' | 'confirming' | 'deleting' | 'error';
 })
 export class PrivacyComponent {
   protected readonly auth = inject(AuthService);
-  private readonly firebase = inject(FirebaseService);
+  private readonly firebase = inject(LEDGER_PORT);
   private readonly translation = inject(TranslationService);
 
   protected readonly deleteStatus = signal<DeleteStatus>('idle');

--- a/src/app/components/settings-sheet/settings-sheet.component.ts
+++ b/src/app/components/settings-sheet/settings-sheet.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 import { TranslocoDirective } from '@jsverse/transloco';
 import { AuthService } from '../../services/auth.service';
-import { FirebaseService } from '../../services/firebase.service';
+import { LEDGER_PORT } from '../../ledger/ports/ledger.port';
 import { FitnessStore } from '../../services/fitness-store.service';
 import { PushNotificationService } from '../../services/push-notification.service';
 import { SubscriptionService } from '../../services/subscription.service';
@@ -406,7 +406,7 @@ import { ThemeChoice } from '../../utils/theme';
 })
 export class SettingsSheetComponent implements AfterViewInit {
   protected readonly auth = inject(AuthService);
-  protected readonly firebase = inject(FirebaseService);
+  protected readonly firebase = inject(LEDGER_PORT);
   protected readonly store = inject(FitnessStore);
   protected readonly pushService = inject(PushNotificationService);
   protected readonly subs = inject(SubscriptionService);


### PR DESCRIPTION
## Summary

Phase 2 of the LedgerStore refactor (#6). Swaps `inject(FirebaseService)` for `inject(LEDGER_PORT)` in the four sites that previously bypassed FitnessStore and reached into Firestore directly.

- `app.ts` — reads `profile` / `profileCompleted` signals
- `onboarding.component.ts` — calls `saveProfile`
- `privacy.component.ts` — calls `exportMyData`, `deleteMyAccount`
- `settings-sheet.component.ts` — calls `saveFcmToken`, `saveReminderHour`

All methods these callers use are already on `LedgerPort`, so this is a token swap with no runtime behavior change. The two affected specs (`app.spec.ts`, `onboarding.component.spec.ts`) now stub `LEDGER_PORT` instead of the concrete `FirebaseService`.

## Why this matters

With Phase 2 merged, `FirebaseService` has only one remaining internal consumer: `FitnessStore`. Phase 3 switches `FitnessStore` to `inject(LEDGER_PORT)`, at which point the whole app depends on the port and the concrete service is free to evolve (rename, split, replace with in-memory for tests, etc.) without touching callers.

Stacks on #7 — merge that first, then this.

## Test plan

- [x] `tsc --noEmit -p tsconfig.app.json` — clean
- [x] `tsc --noEmit -p tsconfig.spec.json` — clean
- [x] `ng build` — succeeds
- [x] `ng test` — 91 passed / 2 skipped / 0 failed
- [ ] Manual smoke after merge: sign in → onboarding save → settings → privacy export/delete (no runtime change expected)
