### PR TITLE
refactor(ledger): switch FitnessStore to LEDGER_PORT (phase 3 of #6)

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -61,9 +61,7 @@ export const appConfig: ApplicationConfig = {
     // skipped and this handler silently passes through — no user-visible
     // difference from the default Angular handler.
     { provide: ErrorHandler, useValue: Sentry.createErrorHandler() },
-    // Phase 1 of the LedgerStore refactor (issue #6): expose FirebaseService
-    // through the LEDGER_PORT injection token so future consumers and tests
-    // can bind to the port without touching the concrete service.
+    // LedgerStore seam (#6): the app depends on LEDGER_PORT; FirebaseService is one impl.
     { provide: LEDGER_PORT, useExisting: FirebaseService },
   ],
 };

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 import { SwUpdate } from '@angular/service-worker';
 import { App } from './app';
 import { AuthService } from './services/auth.service';
-import { FirebaseService } from './services/firebase.service';
+import { LEDGER_PORT } from './ledger/ports/ledger.port';
 import { FitnessStore } from './services/fitness-store.service';
 import { PushNotificationService } from './services/push-notification.service';
 import { Messaging } from '@angular/fire/messaging';
@@ -42,7 +42,7 @@ describe('App', () => {
           },
         },
         {
-          provide: FirebaseService,
+          provide: LEDGER_PORT,
           useValue: {
             profile: signal(null),
             profileCompleted: signal(false),

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -20,7 +20,7 @@ import { SettingsSheetComponent } from './components/settings-sheet/settings-she
 import { MobileTabsComponent, type MobileTab } from './components/mobile-tabs/mobile-tabs.component';
 import { MobileFabComponent } from './components/mobile-fab/mobile-fab.component';
 import { AuthService } from './services/auth.service';
-import { FirebaseService } from './services/firebase.service';
+import { LEDGER_PORT } from './ledger/ports/ledger.port';
 import { FitnessStore } from './services/fitness-store.service';
 import { SubscriptionService } from './services/subscription.service';
 import { ThemeChoice, PRO_THEMES, isProTheme, readStoredTheme, writeStoredTheme } from './utils/theme';
@@ -378,7 +378,7 @@ import { EntryFormManager } from './services/entry-form-manager.service';
 })
 export class App {
   protected readonly auth = inject(AuthService);
-  protected readonly firebase = inject(FirebaseService);
+  protected readonly firebase = inject(LEDGER_PORT);
   protected readonly store = inject(FitnessStore); // triggers lifecycle via constructor effect
   protected readonly subs = inject(SubscriptionService);
   private readonly upsell = inject(UpsellService);

--- a/src/app/components/onboarding/onboarding.component.spec.ts
+++ b/src/app/components/onboarding/onboarding.component.spec.ts
@@ -4,7 +4,7 @@ import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { afterEach, describe, beforeEach, expect, it, vi } from 'vitest';
 import { provideTranslocoConfig } from '../../i18n/transloco.providers';
-import { FirebaseService } from '../../services/firebase.service';
+import { LEDGER_PORT } from '../../ledger/ports/ledger.port';
 import { TranslationService } from '../../services/translation.service';
 import { OnboardingComponent } from './onboarding.component';
 
@@ -28,7 +28,7 @@ describe('OnboardingComponent', () => {
         provideTranslocoConfig(),
         TranslationService,
         {
-          provide: FirebaseService,
+          provide: LEDGER_PORT,
           useValue: {
             profile: signal(null),
             saveProfile,

--- a/src/app/components/onboarding/onboarding.component.ts
+++ b/src/app/components/onboarding/onboarding.component.ts
@@ -2,12 +2,12 @@ import { ChangeDetectionStrategy, Component, computed, effect, inject, input, ou
 import { FormsModule } from '@angular/forms';
 import { TranslocoDirective } from '@jsverse/transloco';
 import {
-  FirebaseService,
   ActivityLevel,
   CutPace,
   ProfileFields,
   Sex,
 } from '../../services/firebase.service';
+import { LEDGER_PORT } from '../../ledger/ports/ledger.port';
 import { TranslationService } from '../../services/translation.service';
 
 type Status = 'idle' | 'saving' | 'error';
@@ -466,7 +466,7 @@ interface OnboardingDraft {
   `],
 })
 export class OnboardingComponent {
-  private readonly firebase = inject(FirebaseService);
+  private readonly firebase = inject(LEDGER_PORT);
   private readonly translation = inject(TranslationService);
 
   /** When true, we're editing an existing profile rather than creating one. */

--- a/src/app/components/privacy/privacy.component.ts
+++ b/src/app/components/privacy/privacy.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { TranslocoDirective } from '@jsverse/transloco';
 import { AuthService } from '../../services/auth.service';
-import { FirebaseService } from '../../services/firebase.service';
+import { LEDGER_PORT } from '../../ledger/ports/ledger.port';
 import { TranslationService } from '../../services/translation.service';
 import { extractErrorCode } from '../../models/error-codes';
 
@@ -157,7 +157,7 @@ type DeleteStatus = 'idle' | 'confirming' | 'deleting' | 'error';
 })
 export class PrivacyComponent {
   protected readonly auth = inject(AuthService);
-  private readonly firebase = inject(FirebaseService);
+  private readonly firebase = inject(LEDGER_PORT);
   private readonly translation = inject(TranslationService);
 
   protected readonly deleteStatus = signal<DeleteStatus>('idle');

--- a/src/app/components/settings-sheet/settings-sheet.component.ts
+++ b/src/app/components/settings-sheet/settings-sheet.component.ts
@@ -4,7 +4,7 @@ import {
 } from '@angular/core';
 import { TranslocoDirective } from '@jsverse/transloco';
 import { AuthService } from '../../services/auth.service';
-import { FirebaseService } from '../../services/firebase.service';
+import { LEDGER_PORT } from '../../ledger/ports/ledger.port';
 import { FitnessStore } from '../../services/fitness-store.service';
 import { PushNotificationService } from '../../services/push-notification.service';
 import { SubscriptionService } from '../../services/subscription.service';
@@ -406,7 +406,7 @@ import { ThemeChoice } from '../../utils/theme';
 })
 export class SettingsSheetComponent implements AfterViewInit {
   protected readonly auth = inject(AuthService);
-  protected readonly firebase = inject(FirebaseService);
+  protected readonly firebase = inject(LEDGER_PORT);
   protected readonly store = inject(FitnessStore);
   protected readonly pushService = inject(PushNotificationService);
   protected readonly subs = inject(SubscriptionService);

--- a/src/app/ledger/infrastructure/in-memory-ledger.adapter.spec.ts
+++ b/src/app/ledger/infrastructure/in-memory-ledger.adapter.spec.ts
@@ -84,6 +84,50 @@ describe('InMemoryLedgerAdapter (LedgerPort contract)', () => {
       await port.deleteLog(entry.id!);
       expect(await port.getRecentLogs()).toEqual([]);
     });
+
+    it('updateLog rejects on unknown id, matching Firestore updateDoc', async () => {
+      await expect(port.updateLog('nope', { calories: 10 })).rejects.toThrow();
+    });
+
+    it('deleteLog rejects on unknown id', async () => {
+      await expect(port.deleteLog('nope')).rejects.toThrow();
+    });
+
+    it('exerciseCompleted=false clears the flag, matching deleteField() in prod', async () => {
+      await port.addLog({ calories: 100, exerciseCompleted: true, timestamp: new Date('2026-04-22') });
+      const [entry] = await port.getRecentLogs();
+      expect(entry.exerciseCompleted).toBe(true);
+      await port.updateLog(entry.id!, { calories: 100, exerciseCompleted: false });
+      expect((await port.getRecentLogs())[0].exerciseCompleted).toBeUndefined();
+    });
+
+    it('addLog without a timestamp uses now()', async () => {
+      const before = Date.now();
+      await port.addLog({ calories: 50 });
+      const [entry] = await port.getRecentLogs();
+      expect(entry.date.getTime()).toBeGreaterThanOrEqual(before);
+      expect(entry.date.getTime()).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  describe('profile idempotency', () => {
+    it('saveProfile preserves ageConfirmedAt across subsequent saves', async () => {
+      await port.ensureUserProfile();
+      const fields: ProfileFields = {
+        heightIn: 70,
+        age: 30,
+        sex: 'male',
+        activityLevel: 'moderate',
+        targetPaceLbsPerWeek: 1.0,
+        ageConfirmed: true,
+      };
+      await port.saveProfile(fields);
+      const firstStamp = port.profile()?.ageConfirmedAt;
+      expect(firstStamp).toBeDefined();
+
+      await port.saveProfile({ ...fields, ageConfirmed: true });
+      expect(port.profile()?.ageConfirmedAt).toBe(firstStamp);
+    });
   });
 
   describe('dailyWater clamping', () => {

--- a/src/app/ledger/infrastructure/in-memory-ledger.adapter.ts
+++ b/src/app/ledger/infrastructure/in-memory-ledger.adapter.ts
@@ -38,12 +38,6 @@ export class InMemoryLedgerAdapter implements LedgerPort {
   private readonly water: Record<string, number> = {};
   private report: WeeklyReport | null = null;
 
-  /** Test hook: simulate a signed-in user with no profile doc yet. */
-  setAuthenticatedUser(email: string): void {
-    // no-op in-memory — ensureUserProfile drives the real lifecycle
-    void email;
-  }
-
   /** Test hook: pre-seed a weekly report (prod writes are server-only). */
   seedLatestReport(report: WeeklyReport | null): void {
     this.report = report;
@@ -167,7 +161,7 @@ export class InMemoryLedgerAdapter implements LedgerPort {
 
   async updateLog(logId: string, entry: LogEntry): Promise<void> {
     const existing = this.logs.get(logId);
-    if (!existing) return;
+    if (!existing) throw new Error(`Log not found: ${logId}`);
     this.logs.set(logId, {
       ...existing,
       calories: entry.calories,
@@ -182,7 +176,7 @@ export class InMemoryLedgerAdapter implements LedgerPort {
   }
 
   async deleteLog(logId: string): Promise<void> {
-    this.logs.delete(logId);
+    if (!this.logs.delete(logId)) throw new Error(`Log not found: ${logId}`);
   }
 
   async getDailyWeights(): Promise<Record<string, number>> {
@@ -211,7 +205,7 @@ export class InMemoryLedgerAdapter implements LedgerPort {
   }
 
   async deletePreset(presetId: string): Promise<void> {
-    this.presets.delete(presetId);
+    if (!this.presets.delete(presetId)) throw new Error(`Preset not found: ${presetId}`);
   }
 
   async getLatestReport(): Promise<WeeklyReport | null> {
@@ -230,7 +224,7 @@ export class InMemoryLedgerAdapter implements LedgerPort {
   }
 
   async deleteMeasurement(id: string): Promise<void> {
-    this.measurements.delete(id);
+    if (!this.measurements.delete(id)) throw new Error(`Measurement not found: ${id}`);
   }
 
   private patchProfile(

--- a/src/app/ledger/ports/ledger.port.ts
+++ b/src/app/ledger/ports/ledger.port.ts
@@ -40,6 +40,9 @@ export interface LedgerPort {
   exportMyData(): Promise<unknown>;
 
   addLog(entry: LogEntry): Promise<void>;
+  /** Returns up to `days` most-recent log rows, oldest-first. The `days`
+   *  parameter is a row cap, not a date window — a heavy logger may get
+   *  a few days' worth; a sparse logger may span weeks. */
   getRecentLogs(days?: number): Promise<DailyLog[]>;
   updateLog(logId: string, entry: LogEntry): Promise<void>;
   deleteLog(logId: string): Promise<void>;

--- a/src/app/services/fitness-store.service.spec.ts
+++ b/src/app/services/fitness-store.service.spec.ts
@@ -3,7 +3,8 @@ import { signal, WritableSignal } from '@angular/core';
 import { vi } from 'vitest';
 import { FitnessStore, PresetLimitError, PRESET_LIMIT_FREE } from './fitness-store.service';
 import { AuthService } from './auth.service';
-import { FirebaseService, DailyLog, LogEntry, MealPreset, UserProfile } from './firebase.service';
+import { LEDGER_PORT } from '../ledger/ports/ledger.port';
+import { DailyLog, LogEntry, MealPreset, UserProfile } from './firebase.service';
 import { TdeeCalculatorService } from './tdee-calculator.service';
 import { GeminiService } from './gemini.service';
 import { SubscriptionService } from './subscription.service';
@@ -118,7 +119,7 @@ describe('FitnessStore', () => {
             emailVerified: signal(true),
           },
         },
-        { provide: FirebaseService, useValue: mockFb },
+        { provide: LEDGER_PORT, useValue: mockFb },
         {
           // Stub TranslationService so the test bed doesn't have to pull in
           // the full Transloco provider chain (TRANSLOCO_TRANSPILER etc).

--- a/src/app/services/fitness-store.service.ts
+++ b/src/app/services/fitness-store.service.ts
@@ -128,7 +128,7 @@ export class FitnessStore {
     const seen = new Set<string>();
     const out: DailyLog[] = [];
     const list = this._logs();
-    // `_logs()` is oldest-first (LedgerPort.getRecentLogs reverses
+    // `_logs()` is oldest-first (the adapter reverses
     // the desc-ordered query before returning). Iterate end-to-start so
     // the user sees their newest meals first.
     for (let i = list.length - 1; i >= 0 && out.length < 5; i--) {

--- a/src/app/services/fitness-store.service.ts
+++ b/src/app/services/fitness-store.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Signal, computed, effect, inject, signal } from '@angular/core';
 import { AuthService } from './auth.service';
+import { LEDGER_PORT } from '../ledger/ports/ledger.port';
 import {
-  FirebaseService,
   DailyLog,
   LogEntry,
   MealPreset,
@@ -66,7 +66,7 @@ export interface TodaySummary {
  * auto-refresh all consumers via Angular signals.
  *
  * Components inject this one service and read signals. They never
- * call FirebaseService or TdeeCalculatorService directly.
+ * call LEDGER_PORT or TdeeCalculatorService directly.
  *
  * Lifecycle: loads on sign-in, clears on sign-out — driven by an
  * effect watching AuthService.isSignedIn().
@@ -74,7 +74,7 @@ export interface TodaySummary {
 @Injectable({ providedIn: 'root' })
 export class FitnessStore {
   private readonly auth = inject(AuthService);
-  private readonly fb = inject(FirebaseService);
+  private readonly fb = inject(LEDGER_PORT);
   private readonly calc = inject(TdeeCalculatorService);
   private readonly gemini = inject(GeminiService);
   private readonly subs = inject(SubscriptionService);
@@ -128,7 +128,7 @@ export class FitnessStore {
     const seen = new Set<string>();
     const out: DailyLog[] = [];
     const list = this._logs();
-    // `_logs()` is oldest-first (FirebaseService.getRecentLogs reverses
+    // `_logs()` is oldest-first (LedgerPort.getRecentLogs reverses
     // the desc-ordered query before returning). Iterate end-to-start so
     // the user sees their newest meals first.
     for (let i = list.length - 1; i >= 0 && out.length < 5; i--) {


### PR DESCRIPTION
## Summary

Phase 3 of the LedgerStore refactor (#6). FitnessStore now injects `LEDGER_PORT` instead of the concrete `FirebaseService`.

With this PR landed, **no consumer in the app graph still injects `FirebaseService` directly** — the concrete service is only named in `app.config.ts` as the backing implementation for the port. The seam is fully in place.

## What's unlocked

- FitnessStore is now unit-testable against `InMemoryLedgerAdapter` from Phase 1 — no Firebase emulator required.
- The concrete `FirebaseService` can be split, renamed, or replaced without touching any caller.
- Phases 4 (remove the `await op; await _load()` idiom) and 5 (narrow the port signature — explicit UID, `Result<T>`, domain-typed drafts) now have a clean foundation.

Stacks on #8. Merge order: #7 → #8 → this.

## Test plan

- [x] `tsc --noEmit -p tsconfig.app.json` — clean
- [x] `tsc --noEmit -p tsconfig.spec.json` — clean
- [x] `ng build` — succeeds
- [x] `ng test` — 91 passed / 2 skipped / 0 failed (FitnessStore spec now stubs `LEDGER_PORT`)
- [ ] Manual smoke after merge: addLog → edit → delete with undo; verify dashboard, weekly report caching, travel-mode toggle (no runtime change expected)
