### PR TITLE
chore: launch-as-individual — legal hardening + PII minimization

### DIFF
--- a/apps/mobile/MOBILE_RELEASE.md
+++ b/apps/mobile/MOBILE_RELEASE.md
@@ -18,10 +18,25 @@ v1.1. That removes the single biggest blocker from the first submission.
   → Firebase `OAuthProvider('apple.com')` in `src/lib/auth.tsx`.
 - Permission hygiene: camera usage string set; mic/RECORD_AUDIO removed.
 
+## Account type: INDIVIDUAL (no LLC) — decided 2026-07-07
+
+The Wyoming-LLC plan was **dropped** (foreign-LLC-in-PR yearly fees vs $0
+income). Launching as a **sole individual** in the owner's own legal name.
+Consequences to know before enrolling:
+
+- **Apple: Individual enrollment** ($99/yr). **No D-U-N-S needed** — that was
+  the org-only long pole, so this is the *faster* path. Your **legal name shows
+  publicly as the seller** on the App Store (owner accepted this).
+- **Google Play: Individual** developer account ($25 one-time). Google also
+  shows your name (and, for the required contact, often an address) publicly.
+- **No Stripe / no IAP in v1** — the app is free, so there is no payment entity
+  to set up and no billing PII. (Pro + IAP is v1.1; revisit an entity then if
+  revenue appears.)
+
 ## 🚫 Owner-gated blockers (need your Apple/Google/EAS accounts)
 
-1. **Apple Developer Program** ($99/yr) + an App Store Connect app record.
-   Play Console ($25 one-time) for Android.
+1. **Apple Developer Program — Individual** ($99/yr) + an App Store Connect app
+   record. **Play Console — Individual** ($25 one-time) for Android.
 2. **Enable Apple as a sign-in provider** — Firebase Console → Auth → Sign-in
    method → Apple (enable); Apple Developer portal → enable "Sign in with
    Apple" capability on the `fit.ignia.app` App ID. (Code is already in.)
@@ -29,11 +44,42 @@ v1.1. That removes the single biggest blocker from the first submission.
    `eas build -p ios --profile production` (and `-p android`). First iOS build
    provisions signing certs interactively. This is also the only way to test
    the native-gated features (Apple/Google sign-in) — they can't run in Expo Go.
+   **See "Builds without paying EAS" below** — the free tier is enough.
 4. **App privacy details ("nutrition label").** App Store Connect + Play Data
    Safety. We collect **health data** (weight, body metrics) + email — declare
    accurately. See `docs/APP_STORE_LISTING.md` for the exact mapping.
+   (Progress photos were removed pre-launch — do **not** declare Photos.)
 5. **Store listing assets.** Screenshots per device class, description,
    keywords, support + marketing URL. Draft copy in `docs/APP_STORE_LISTING.md`.
+
+## Builds without paying EAS (owner is on Windows)
+
+You do **not** need the paid EAS plan. Two facts drive this:
+
+- **iOS builds require macOS somewhere.** You're on Windows, so
+  `eas build --local` is **not possible for iOS** (no Xcode/macOS). Your only
+  no-Mac iOS path is **EAS cloud build on the FREE tier**: a limited number of
+  builds per month on a slower "free-tier" queue (you wait behind paid users).
+  For an app that ships a few times a month, that is completely fine — slow ≠
+  blocking. Do **not** buy the Production/paid plan for this.
+  ```sh
+  cd apps/mobile
+  npx eas-cli login
+  npx eas-cli build -p ios --profile production      # cloud, free tier
+  npx eas-cli submit -p ios --latest                 # upload to App Store Connect
+  ```
+- **Android can build locally on Windows for free (unlimited).** With the
+  Android SDK + JDK installed, `--local` runs on your machine, no EAS queue:
+  ```sh
+  npx eas-cli build -p android --profile production --local
+  # → produces an .aab; upload it in Play Console, or:
+  npx eas-cli submit -p android --latest
+  ```
+  Or just use the free EAS cloud tier for Android too if you don't want to set
+  up the local Android toolchain.
+
+Bottom line: **free EAS tier covers iOS; local build covers Android.** The
+"infinite builds" paid plan only buys speed and concurrency you don't need yet.
 
 ## Deferred to v1.1 (post-launch)
 - **Pro tier + StoreKit IAP** (RevenueCat or react-native-iap + receipt-trust
@@ -43,9 +89,10 @@ v1.1. That removes the single biggest blocker from the first submission.
 - App Check (abuse/quota protection) — see `docs/DEV_ENVIRONMENT.md`.
 
 ## Recommended order (v1)
-Apple Dev + Play accounts → enable Apple provider (Firebase + portal) → first
-EAS dev build (test Apple/Google sign-in on device) → privacy labels + store
-metadata → `eas build --profile production` → `eas submit`.
+Apple Dev (Individual) + Play (Individual) accounts → enable Apple provider
+(Firebase + portal) → first EAS **free-tier** dev build (test Apple/Google
+sign-in on device) → privacy labels + store metadata → `eas build --profile
+production` (iOS cloud free-tier; Android `--local`) → `eas submit`.
 
 **With free v1, the app IS submittable** once the account + Apple-provider +
 metadata steps above are done — no IAP gate anymore.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -10,7 +10,7 @@
     "backgroundColor": "#faf9f6",
     "ios": {
       "bundleIdentifier": "fit.ignia.app",
-      "supportsTablet": true,
+      "supportsTablet": false,
       "usesAppleSignIn": true,
       "infoPlist": {
         "CFBundleURLTypes": [

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,10 +16,11 @@
         "CFBundleURLTypes": [
           {
             "CFBundleURLSchemes": [
-              "com.googleusercontent.apps.647810616435-h0cjjths1qefusi2erohqm94e75gdnmi"
+              "com.googleusercontent.apps.647810616435-66v806q2ptpso47ldcgq7h3bdq6h327j"
             ]
           }
-        ]
+        ],
+        "ITSAppUsesNonExemptEncryption": false
       }
     },
     "android": {
@@ -75,7 +76,7 @@
     ],
     "extra": {
       "googleAuth": {
-        "iosClientId": "647810616435-h0cjjths1qefusi2erohqm94e75gdnmi.apps.googleusercontent.com",
+        "iosClientId": "647810616435-66v806q2ptpso47ldcgq7h3bdq6h327j.apps.googleusercontent.com",
         "androidClientId": "647810616435-8fq849lqju9rrbnva3nqsvdqlbucr33n.apps.googleusercontent.com",
         "webClientId": "647810616435-jkiccn16plimkv9smp7ki8m90ghhocsh.apps.googleusercontent.com"
       },

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -16,7 +16,8 @@
         "CFBundleURLTypes": [
           {
             "CFBundleURLSchemes": [
-              "com.googleusercontent.apps.647810616435-66v806q2ptpso47ldcgq7h3bdq6h327j"
+              "com.googleusercontent.apps.647810616435-66v806q2ptpso47ldcgq7h3bdq6h327j",
+              "fit.ignia.app"
             ]
           }
         ],

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "dependencies": {
     "@expo-google-fonts/manrope": "^0.4.2",
-    "@expo/ui": "~0.2.0-beta.9",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "expo": "^54.0.35",
@@ -13,6 +12,7 @@
     "expo-camera": "~17.0.10",
     "expo-constants": "~18.0.13",
     "expo-crypto": "~15.0.9",
+    "expo-dev-client": "~6.0.21",
     "expo-device": "~8.0.10",
     "expo-document-picker": "~14.0.8",
     "expo-font": "~14.0.12",

--- a/apps/mobile/src/app/(app)/settings.tsx
+++ b/apps/mobile/src/app/(app)/settings.tsx
@@ -9,7 +9,7 @@ import { useAuth } from '@/lib/auth';
 import { useDailyTargets } from '@/hooks/useDailyTargets';
 import { importLogs, setCalorieFloor, setPreferredLocale, setUnitSystem, setWeeklyDigestOptIn } from '@/lib/ledger';
 import { exportDataCsv } from '@/lib/dataExport';
-import { useSubscription } from '@/lib/subscription';
+import { useSubscription, PRO_ENABLED } from '@/lib/subscription';
 import { DEFAULT_REMINDER_HOUR, getReminder, setReminder } from '@/lib/reminders';
 import { type I18nKey, type Locale, useLocale, useT } from '@/i18n';
 import * as haptics from '@/lib/haptics';
@@ -245,6 +245,8 @@ export default function Settings() {
           </TouchableOpacity>
         </View>
 
+        {PRO_ENABLED ? (
+        <>
         <Text style={styles.section}>{t('pro.title')}</Text>
         <View style={styles.card}>
           {isPro ? (
@@ -283,6 +285,8 @@ export default function Settings() {
             />
           </View>
         </View>
+        </>
+        ) : null}
 
         <Text style={styles.section}>{t('settings.invite')}</Text>
         <View style={styles.card}>

--- a/apps/mobile/src/app/(app)/trends.tsx
+++ b/apps/mobile/src/app/(app)/trends.tsx
@@ -7,7 +7,7 @@ import { type TdeeResult, type WeeklyBudget, type WeeklyInsights, parseYmd } fro
 import { HeaderAvatar } from '@/components/HeaderAvatar';
 import { WeeklyReportCard } from '@/components/WeeklyReportCard';
 import { useTrends } from '@/hooks/useTrends';
-import { useSubscription } from '@/lib/subscription';
+import { useSubscription, PRO_ENABLED } from '@/lib/subscription';
 import { type I18nKey, type TFn, useT } from '@/i18n';
 import * as haptics from '@/lib/haptics';
 import { CountUpText, enterUp, PressScale } from '@/lib/motion';
@@ -133,10 +133,13 @@ export default function Trends() {
             )}
           </Animated.View>
 
-          {/* 5. Weekly report — deepest Pro layer (self-gating card). */}
-          <Animated.View entering={enterUp(4)}>
-            <WeeklyReportCard />
-          </Animated.View>
+          {/* 5. Weekly report — Pro + server-entitled AI feature; hidden in
+              the free v1 (no IAP → its "PRO" tag + generate would dead-end). */}
+          {PRO_ENABLED ? (
+            <Animated.View entering={enterUp(4)}>
+              <WeeklyReportCard />
+            </Animated.View>
+          ) : null}
         </ScrollView>
       )}
     </SafeAreaView>

--- a/apps/mobile/src/app/onboarding.tsx
+++ b/apps/mobile/src/app/onboarding.tsx
@@ -36,7 +36,7 @@ export default function Onboarding() {
   const t = useT();
   const styles = useThemedStyles(createStyles);
   const { colors } = useTheme();
-  const { user, profile } = useAuth();
+  const { user, profile, signOut } = useAuth();
   const router = useRouter();
   // A completed profile only reaches this screen via Settings → "Edit goals":
   // skip the welcome greeting and return to Settings when done.
@@ -123,7 +123,17 @@ export default function Onboarding() {
               ))}
             </View>
           ) : null}
-          <View style={styles.back} />
+          {/* Sign out — escape hatch so a user can leave onboarding (e.g. wrong
+              account) instead of being trapped on the flow. */}
+          <PressScale
+            style={styles.back}
+            scaleTo={0.9}
+            onPress={() => { void signOut(); }}
+            testID="onboarding-signout"
+            accessibilityLabel={t('settings.signOut')}
+          >
+            <Ionicons name="log-out-outline" size={22} color={colors.faint} />
+          </PressScale>
         </View>
 
         <Animated.View key={step} entering={entering} style={styles.stepWrap}>

--- a/apps/mobile/src/components/BrandLoader.tsx
+++ b/apps/mobile/src/components/BrandLoader.tsx
@@ -79,5 +79,8 @@ export function BrandLoader() {
 const styles = StyleSheet.create({
   wrap: { alignItems: 'center', gap: space.lg },
   ember: { position: 'absolute', bottom: SIZE * 0.34, width: 5, height: 5, borderRadius: 3 },
-  word: { fontFamily: type.display, fontSize: font.h1, letterSpacing: 1.5 },
+  // paddingHorizontal + textAlign guard against iOS clipping the final glyph:
+  // letterSpacing on a custom display font makes RN under-measure the text
+  // width, chopping the trailing "a". The padding gives it room.
+  word: { fontFamily: type.display, fontSize: font.h1, letterSpacing: 1.5, paddingHorizontal: 8, textAlign: 'center' },
 });

--- a/apps/mobile/src/i18n/en.ts
+++ b/apps/mobile/src/i18n/en.ts
@@ -270,7 +270,7 @@ export const en = {
   'coach.errRate': 'Too many requests — give it a moment and try again.',
   'coach.errAuth': 'Please sign in again to use the coach.',
   'coach.errGeneric': 'Something went wrong. Please try again.',
-  'coach.upgradeHint': 'Go Pro for more daily coaching.',
+  'coach.upgradeHint': "You've reached today's coaching limit — it resets tomorrow.",
 
   // ── weekly report (Pro) ──
   'report.title': 'Weekly report',

--- a/apps/mobile/src/i18n/es-PR.ts
+++ b/apps/mobile/src/i18n/es-PR.ts
@@ -272,7 +272,7 @@ export const esPR: Record<I18nKey, string> = {
   'coach.errRate': 'Demasiadas solicitudes — espera un momento e inténtalo otra vez.',
   'coach.errAuth': 'Vuelve a iniciar sesión para usar el coach.',
   'coach.errGeneric': 'Algo salió mal. Inténtalo de nuevo.',
-  'coach.upgradeHint': 'Hazte Pro para más coaching diario.',
+  'coach.upgradeHint': 'Llegaste al límite de coaching de hoy — se reinicia mañana.',
 
   // ── reporte semanal (Pro) ──
   'report.title': 'Reporte semanal',

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -191,8 +191,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         let credential: AppleAuthentication.AppleAuthenticationCredential;
         try {
           credential = await AppleAuthentication.signInAsync({
+            // PII minimization: only request EMAIL. We never read
+            // `credential.fullName`, so requesting FULL_NAME would collect
+            // a real name we don't use (and would populate the Firebase Auth
+            // displayName). Email alone is enough to create the account.
             requestedScopes: [
-              AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
               AppleAuthentication.AppleAuthenticationScope.EMAIL,
             ],
             nonce: hashedNonce,

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -23,7 +23,7 @@ import {
 } from 'react';
 import type { Profile } from '@macrolog/core';
 import { auth } from './firebase';
-import { subscribeProfile } from './ledger';
+import { ensureProfile, subscribeProfile } from './ledger';
 
 // Required for the web-OAuth popup/redirect to resolve when the app
 // regains focus after the Google consent screen.
@@ -123,6 +123,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return onAuthStateChanged(auth, async (u) => {
       setUser(u);
       if (u) {
+        // Create users/{uid} on first sign-in if it doesn't exist yet, so a
+        // mobile-first new user has a profile doc for onboarding to update.
+        // Best-effort: a failure here surfaces later as a save error, not a
+        // dead sign-in. Runs before the profile subscription resolves.
+        try {
+          await ensureProfile(u.uid);
+        } catch (e) {
+          console.warn('ensureProfile failed', e);
+        }
         try {
           const token = await u.getIdTokenResult();
           // Mirrors the PWA's SubscriptionService: Pro = stripeRole "paid".

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -186,7 +186,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           throw new GoogleSignInError('cancelled');
         }
         if (result.type !== 'success') throw new GoogleSignInError('failed');
-        const idToken = result.params?.id_token;
+        // On iOS/Android, useIdTokenAuthRequest runs the authorization-code
+        // flow and auto-exchanges the code — the id_token comes back in
+        // `authentication`, NOT `params`. (params only carries it on the
+        // web/implicit path.) Reading only params → "no-token" → the generic
+        // "Could not sign in" error even though sign-in succeeded up to here.
+        const idToken = result.authentication?.idToken ?? result.params?.id_token;
         if (!idToken) throw new GoogleSignInError('no-token');
         await signInWithCredential(auth, GoogleAuthProvider.credential(idToken));
       },

--- a/apps/mobile/src/lib/ledger.ts
+++ b/apps/mobile/src/lib/ledger.ts
@@ -300,6 +300,23 @@ export function subscribeProfile(
   );
 }
 
+/** Idempotent profile bootstrap — mirrors the PWA's
+ *  `FirebaseService.ensureUserProfile`. The web app creates `users/{uid}` on
+ *  first sign-in; a user who signs up FIRST on mobile never hits that path, so
+ *  without this their onboarding save (`saveOnboardingV2` = an `updateDoc`)
+ *  writes to a non-existent doc and fails with "Could not save." Call on every
+ *  sign-in. No email is stored (PII minimization — email lives only in Auth). */
+export async function ensureProfile(uid: string): Promise<void> {
+  const ref = userDoc(uid);
+  const snap = await getDoc(ref);
+  if (snap.exists()) {
+    await updateDoc(ref, { lastSeenAt: Timestamp.now() });
+    return;
+  }
+  const now = Timestamp.now();
+  await setDoc(ref, { createdAt: now, lastSeenAt: now, profileCompleted: false });
+}
+
 /** Persist the 2-question onboarding. Mirrors the PWA's
  *  `FirebaseService.saveOnboardingV2` byte-for-byte: writes the manual
  *  heuristic targets, stamps completion, and flips `profileCompleted` so the

--- a/apps/mobile/src/lib/subscription.ts
+++ b/apps/mobile/src/lib/subscription.ts
@@ -5,6 +5,15 @@ import { useAuth } from '@/lib/auth';
 const OVERRIDE_KEY = 'proPreview';
 
 /**
+ * Pro tier is NOT available in v1 — there is no IAP yet (see MOBILE_RELEASE).
+ * While disabled: every gated feature is unlocked for everyone (`isPro` is
+ * always true) and all purchase/upsell/testing surfaces are hidden. Shipping a
+ * paywall with no purchasable product is an App Store rejection (Guideline
+ * 2.1/3.1.1). Flip to `true` in v1.1 once StoreKit lands.
+ */
+export const PRO_ENABLED = false;
+
+/**
  * Pro entitlement for the mobile app. Real source is `useAuth().isPro` (the
  * Stripe `stripeRole:paid` custom claim — so a web-Pro user is Pro on mobile
  * too). A persisted local `preview` flag lets the owner/testers toggle Pro ON
@@ -29,5 +38,6 @@ export function useSubscription(): {
     await AsyncStorage.setItem(OVERRIDE_KEY, on ? '1' : '0');
   }, []);
 
-  return { isPro: entitled || proPreview, proPreview, setProPreview };
+  // Pro disabled in v1 → everything unlocked for everyone.
+  return { isPro: PRO_ENABLED ? entitled || proPreview : true, proPreview, setProPreview };
 }

--- a/docs/APP_STORE_LISTING.md
+++ b/docs/APP_STORE_LISTING.md
@@ -4,6 +4,8 @@ Draft metadata for the first (free) submission. Edit to taste; character
 limits noted. Support/marketing/privacy URLs assume `ignia.fit` is live.
 
 ## Names & URLs
+- **Seller / developer name:** the owner's **individual legal name** (no LLC —
+  decided 2026-07-07). This shows publicly on both stores. App is still "Ignia".
 - **App name:** Ignia
 - **Subtitle** (iOS, ≤30 chars): `Calorie & protein tracker` (25)
 - **Promotional text** (iOS, ≤170, editable without review): `Track calories,
@@ -50,7 +52,6 @@ fasting, and a clean daily dashboard.`
 | Email address | Contact Info → Email | Personal info → Email | Account / App functionality |
 | Weight, body measurements, body-fat | Health & Fitness | Health & fitness | App functionality |
 | Food/calorie logs, workouts, fasting, water, sleep | Health & Fitness / Other usage data | Health & fitness | App functionality |
-| Progress photos (optional, user-uploaded) | Photos (User Content) | Photos/videos | App functionality (stored in the user's account) |
 | User ID (Firebase UID) | Identifiers | App activity / IDs | App functionality |
 | Crash / diagnostics (Sentry, if DSN set) | Diagnostics | App info & performance → Crash logs | App functionality |
 

--- a/docs/LAUNCH_CHECKLIST.md
+++ b/docs/LAUNCH_CHECKLIST.md
@@ -1,0 +1,97 @@
+# Ignia v1 launch runbook (individual, Windows)
+
+One ordered checklist from "store accounts approved" → "submitted." Assumes the
+**individual** account decision (2026-07-07) and a **Windows** dev machine (no
+Mac). Metadata/privacy-label *content* lives in `docs/APP_STORE_LISTING.md`; the
+mobile build/permission status lives in `apps/mobile/MOBILE_RELEASE.md`. This
+file is just the **order of operations + the Windows gotchas**.
+
+Config baseline (from `apps/mobile/app.json`): app `Ignia`, version `1.0.0`,
+bundle/package `fit.ignia.app`, `usesAppleSignIn: true`, prod build forces
+`EXPO_PUBLIC_FEATURE_PHOTO_SCAN=0` (no photo-scan in v1).
+
+---
+
+## 0. In flight now (does not wait on account approval)
+- [ ] **Apple Developer Program — Individual** enrollment submitted ($99/yr).
+- [ ] **Google Play Console — Individual** account created ($25 one-time).
+- [ ] **DECISION: set `supportsTablet: false`** in `app.json` for v1. With it
+      `true`, App Store Connect **requires iPad 13" screenshots to submit** —
+      which you can't capture without an iPad or a Mac simulator. The app is
+      phone-first; dropping native iPad support removes an entire screenshot
+      class and review surface. (Ask Claude to flip it — one line.)
+
+## 1. Once Apple enrollment is APPROVED
+- [ ] **Enable Apple as a sign-in provider** (code is already wired):
+      - Firebase Console → Auth → Sign-in method → **Apple** → enable.
+      - Apple Developer portal → Certificates, IDs & Profiles → the
+        `fit.ignia.app` App ID → enable **Sign in with Apple** capability.
+- [ ] **App Store Connect → create the app record** (name Ignia, bundle
+      `fit.ignia.app`, primary language English, SKU any string).
+
+## 2. First EAS build — FREE tier (test on a real device)
+Windows can't build iOS locally (needs macOS), so iOS uses **EAS cloud, free
+tier** (limited builds/mo, slow queue — fine).
+- [ ] `cd apps/mobile && npx eas-cli login`
+- [ ] `npx eas-cli build -p ios --profile development` → install on your iPhone
+      via the EAS/Expo link. This is the **only** way to test Apple + Google
+      sign-in (they can't run in Expo Go).
+- [ ] Smoke on device: sign in with Apple, sign in with Google, log a meal, log
+      weight. Confirm no crash.
+
+## 3. Screenshots (the Windows-hard part)
+App Store needs **actual app screenshots at exact pixel sizes** — a browser at
+device dimensions is not accepted. Capture on a **physical iPhone**:
+- [ ] Take a production (or preview) build to **TestFlight** (`eas submit` after
+      §5) OR use the dev build already on your phone.
+- [ ] Screenshot on device (Volume-Up + Side button), then AirDrop/email to PC.
+- **iOS required:** iPhone **6.9"** set = **1290 × 2796** px (portrait). If ASC
+      also asks for 6.5", use **1242 × 2688**. No iPad set if you set
+      `supportsTablet: false` in §0.
+- **Android (Play):** ≥2 phone screenshots, 1080 px+ on the short side.
+- [ ] **Google Play feature graphic — 1024 × 500 PNG/JPG (REQUIRED to publish).**
+      Easy to forget; Play won't let you submit without it. (Flame on paper bg.)
+- Suggested shots (both stores): Today rings, meal logging, Trends, Train
+      session, Body/weight — on a seeded account, flame splash.
+
+## 4. Store metadata + privacy labels
+Copy from `docs/APP_STORE_LISTING.md` verbatim:
+- [ ] App name, subtitle, promo text, description, keywords, support +
+      marketing URL (`https://ignia.fit`), **privacy policy URL**
+      (`https://ignia.fit/privacy`).
+- [ ] **Apple privacy "nutrition label"** + **Play Data Safety**: declare
+      **Health & Fitness** (weight/body/logs) + **Email** + **UID** +
+      diagnostics. **Do NOT declare Photos** (progress photos were cut).
+      Answers: not used to track, no third-party ads, not sold, encrypted in
+      transit, in-app deletion = yes, Hide-My-Email supported.
+- [ ] Age rating: **4+** (Apple) / Everyone (Play) — "No" to all restricted
+      content questions.
+- [ ] Because Google sign-in is offered, **Sign in with Apple is required**
+      (guideline 4.8) — it's wired; just make sure the Apple button shows.
+
+## 5. Production build + submit
+- [ ] iOS: `npx eas-cli build -p ios --profile production` (cloud free tier) →
+      `npx eas-cli submit -p ios --latest` (uploads to App Store Connect).
+- [ ] Android: `npx eas-cli build -p android --profile production --local`
+      (free, unlimited, on Windows) → upload the `.aab` in Play Console, or
+      `npx eas-cli submit -p android --latest`.
+- [ ] App Store Connect: attach the build, screenshots, metadata → **Submit for
+      Review**. Add review notes: free app, no IAP; test account creds if a
+      reviewer needs one.
+- [ ] Play Console: create the production release, attach `.aab`, complete the
+      content-rating questionnaire + Data Safety → **Roll out**.
+
+## 6. Post-submit
+- [ ] Respond fast to any reviewer rejection (usual first-timers: privacy-label
+      mismatch, sign-in test account, 4.8 Apple-button placement).
+- [ ] After approval: verify a fresh install signs in + logs on both stores.
+
+---
+
+### Known blockers unique to this setup
+- **No Mac** → iOS builds only via EAS cloud; iOS screenshots only via a
+  physical iPhone. Budget the free-tier build queue wait.
+- **Individual account** → your legal name is the public seller on both stores
+  (accepted 2026-07-07).
+- **Free v1, no IAP** → no StoreKit/Play-Billing products to configure. Pro +
+  photo-scan are v1.1 (see `MOBILE_RELEASE.md`).

--- a/firestore.rules
+++ b/firestore.rules
@@ -64,8 +64,13 @@ service cloud.firestore {
 
     // ─── Profile schema ─────────────────────────────────────────
     function hasProfileBase(data) {
-      return data.keys().hasAll(['email', 'createdAt', 'lastSeenAt', 'profileCompleted'])
-          && data.email is string
+      // `email` is NO LONGER stored on the profile doc (PII minimization —
+      // 2026-07-07): the email lives only in Firebase Auth, so the
+      // health-data store is keyed by opaque uid, not identity. Legacy docs
+      // may still carry it, so it stays ALLOWED (in the hasOnly lists below)
+      // and, when present, must be a string — just no longer REQUIRED.
+      return data.keys().hasAll(['createdAt', 'lastSeenAt', 'profileCompleted'])
+          && (!('email' in data.keys()) || data.email is string)
           && data.createdAt is timestamp
           && data.lastSeenAt is timestamp
           && data.profileCompleted is bool;

--- a/functions/src/public-profile.ts
+++ b/functions/src/public-profile.ts
@@ -1,6 +1,7 @@
 import { onCall, HttpsError } from "firebase-functions/v2/https";
 import { onDocumentUpdated, onDocumentWritten } from "firebase-functions/v2/firestore";
 import { getFirestore, FieldValue, Timestamp } from "firebase-admin/firestore";
+import { getAuth } from "firebase-admin/auth";
 
 // ─── Public profile pages (`/u/<slug>`) ────────────────────────────
 //
@@ -171,8 +172,14 @@ async function buildMirrorFromProfile(
   const totalChange = startWeight != null && currentWeight != null
     ? Math.round((currentWeight - startWeight) * 10) / 10 : null;
 
+  // Email is no longer stored on the profile doc (PII minimization). Keep
+  // the legacy email-localpart fallback for users who enabled a public
+  // profile without setting a display name, but source it from Auth (legacy
+  // docs may still carry `profile.email`; prefer it to save an Auth read).
+  const legacyEmail = (profile["email"] as string | undefined)
+    ?? (await getAuth().getUser(uid).then((u) => u.email).catch(() => undefined));
   const displayName = (profile["publicDisplayName"] as string | undefined)
-    || (profile["email"] as string | undefined)?.split("@")[0]
+    || legacyEmail?.split("@")[0]
     || "Ignia user";
 
   return {

--- a/functions/src/user-lifecycle.ts
+++ b/functions/src/user-lifecycle.ts
@@ -37,7 +37,12 @@ export const sendWelcomeEmail = onDocumentUpdated(
     if (after.welcomeEmailSentAt) return; // already sent
 
     const uid = event.params.uid;
-    const email = after.email as string | undefined;
+    // Email is no longer stored on the profile doc (PII minimization) —
+    // read it from Firebase Auth. Legacy docs may still carry `after.email`;
+    // prefer it to save an Auth read, else fetch by uid.
+    const email =
+      (after.email as string | undefined) ??
+      (await getAuth().getUser(uid).then((u) => u.email).catch(() => undefined));
     if (!email) {
       console.warn(`sendWelcomeEmail: user ${uid} has no email — skipping.`);
       return;

--- a/functions/src/weekly-digest.ts
+++ b/functions/src/weekly-digest.ts
@@ -172,7 +172,12 @@ export async function runWeeklyDigest(): Promise<void> {
         skipped++;
         continue;
       }
-      const email = data["email"] as string | undefined;
+      // Email is no longer on the profile doc (PII minimization) — fetch
+      // from Auth by uid. Legacy docs may still carry it (preferred, saves
+      // an Auth read). Skip if the account has no email at all.
+      const email =
+        (data["email"] as string | undefined) ??
+        (await getAuth().getUser(uid).then((u) => u.email).catch(() => undefined));
       if (!email) {
         skipped++;
         continue;

--- a/functions/test/rules/firestore-rules.spec.ts
+++ b/functions/test/rules/firestore-rules.spec.ts
@@ -93,6 +93,16 @@ describe('firestore.rules', () => {
     await assertFails(setDoc(doc(db, 'users', 'alice'), baseProfile()));
   });
 
+  it('allows profile creation WITHOUT an email field (PII minimization)', async () => {
+    // Email is no longer persisted on the profile doc — it lives only in
+    // Firebase Auth. A verified user must be able to create a profile that
+    // omits `email` entirely.
+    const db = authed('alice');
+    const { email, ...noEmail } = baseProfile();
+    void email;
+    await assertSucceeds(setDoc(doc(db, 'users', 'alice'), noEmail));
+  });
+
   it('blocks cross-user profile reads', async () => {
     // Seed alice's profile via an admin-bypass context so the read target exists.
     await env.withSecurityRulesDisabled(async (ctx) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo-google-fonts/manrope": "^0.4.2",
-        "@expo/ui": "~0.2.0-beta.9",
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
         "expo": "^54.0.35",
@@ -60,6 +59,7 @@
         "expo-camera": "~17.0.10",
         "expo-constants": "~18.0.13",
         "expo-crypto": "~15.0.9",
+        "expo-dev-client": "~6.0.21",
         "expo-device": "~8.0.10",
         "expo-document-picker": "~14.0.8",
         "expo-font": "~14.0.12",
@@ -4984,20 +4984,6 @@
     "node_modules/@expo/sudo-prompt": {
       "version": "9.3.2",
       "license": "MIT"
-    },
-    "node_modules/@expo/ui": {
-      "version": "0.2.0-canary-20260121-a63c0dd",
-      "resolved": "https://registry.npmjs.org/@expo/ui/-/ui-0.2.0-canary-20260121-a63c0dd.tgz",
-      "integrity": "sha512-V3zCuj0XmssM04YzxCeWxKumQ27jUMjroojFq9IVOe0+Ht59nsA/zTK+0KxUn8M+EfFgV8Yqo4A1AV+1fMZ+BQ==",
-      "license": "MIT",
-      "dependencies": {
-        "sf-symbols-typescript": "^2.1.0"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*"
-      }
     },
     "node_modules/@expo/vector-icons": {
       "version": "15.1.1",
@@ -14854,6 +14840,57 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-6.0.21.tgz",
+      "integrity": "sha512-SWI6HD0pa4eJujkYFkvvpezUE1zmJXGLu+34azpu7+QJgO+FLutDYDj8BSTdeH/NYDEClDFjCGqVMcWETvmsCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "6.0.21",
+        "expo-dev-menu": "7.0.19",
+        "expo-dev-menu-interface": "2.0.0",
+        "expo-manifests": "~1.0.11",
+        "expo-updates-interface": "~2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "6.0.21",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-6.0.21.tgz",
+      "integrity": "sha512-QZ9gcKMZbp6EsIhzS0QoGB8Cf4xeVJhjbNgWUwcoBIk8gshoFz8CkCQOnX+HNv2sSY3rdCaNpx3Xo0Rflyq7rA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "expo-dev-menu": "7.0.19",
+        "expo-manifests": "~1.0.11"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-7.0.19.tgz",
+      "integrity": "sha512-ju5MZiBCPhUKKvHy0ElZdnlhq01mkEEiR8jfrgQVvW26aWjzjLiOhppNAyXtvGbhk7WxJim3wYMiqFFrjGdfKA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-2.0.0.tgz",
+      "integrity": "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-device": {
       "version": "8.0.10",
       "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-8.0.10.tgz",
@@ -14965,6 +15002,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "15.0.8",
       "license": "MIT",
@@ -14985,6 +15028,19 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.11.tgz",
+      "integrity": "sha512-6zItytTewN37Cjhp3glUg0ozrgW2GwB8x9wtfzUNoJIMmxO38nnGdTLMaotYhRqdf5PP2Dzdmej1HDHXVNUpRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.13",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {
@@ -15254,6 +15310,15 @@
         "react-native-web": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-web-browser": {

--- a/src/app/components/landing/landing.component.ts
+++ b/src/app/components/landing/landing.component.ts
@@ -214,64 +214,16 @@ import { UiButton } from '../ui/button.component';
         </div>
       </section>
 
-      <!-- ── 4. Pricing ───────────────────────────────────────────── -->
-      <section id="pricing" class="max-w-5xl mx-auto pt-8">
-        <div class="text-center mb-10">
-          <h2 class="v2-display">Simple, transparent pricing.</h2>
-        </div>
-        <div class="grid gap-6 md:grid-cols-2 items-stretch max-w-4xl mx-auto">
-          <!-- Free Tier -->
-          <div class="glass-card flex flex-col p-8 relative overflow-hidden" style="border-radius: var(--v2-radius-xl);">
-            <div class="flex items-baseline justify-between mb-4">
-              <h3 class="v2-h2">{{ t('landing.freeStamp') }}</h3>
-              <span class="v2-num" style="font-size: 2.5rem; font-weight: 800;">{{ t('landing.freePrice') }}</span>
-            </div>
-            <p class="v2-body-soft mb-6">{{ t('landing.freeBody') }}</p>
-            <ul class="space-y-3 mb-8 flex-1">
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-sage);">✓</span> {{ t('landing.freeF1') }}</li>
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-sage);">✓</span> {{ t('landing.freeF2') }}</li>
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-sage);">✓</span> {{ t('landing.freeF3') }}</li>
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-sage);">✓</span> {{ t('landing.freeF4') }}</li>
-            </ul>
-            <a href="/app" class="v2-btn v2-btn--secondary v2-btn--block v2-btn--lg w-full">
-              {{ t('landing.freeCta') }}
-            </a>
-          </div>
-          <!-- Pro Tier -->
-          <div class="glass-card flex flex-col p-8 relative overflow-hidden" style="background: var(--v2-accent-soft); border-color: color-mix(in srgb, var(--v2-accent) 40%, transparent); box-shadow: 0 12px 32px color-mix(in srgb, var(--v2-accent) 15%, transparent); border-radius: var(--v2-radius-xl); transform: scale(1.02); z-index: 10;">
-            <div class="absolute top-0 right-0 p-4">
-              <div class="px-3 py-1 rounded-full text-xs font-bold uppercase tracking-wider" style="background: var(--v2-accent); color: white;">
-                {{ t('landing.proTrialBadge') }}
-              </div>
-            </div>
-            <div class="flex items-baseline justify-between mb-4 mt-2">
-              <h3 class="v2-h2" style="color: var(--v2-accent);">{{ t('landing.proStamp') }}</h3>
-              <div class="text-right">
-                <div class="flex items-center gap-2 justify-end">
-                  @if (subs.displayPriceAnnualAnchor) {
-                    <s class="v2-num text-lg opacity-50">{{ subs.displayPriceAnnualAnchor }}</s>
-                  }
-                  <span class="v2-num" style="font-size: 2.5rem; font-weight: 800; color: var(--v2-accent);">
-                    {{ subs.displayPriceAnnual }}
-                  </span>
-                </div>
-                <div class="v2-caption mt-1 font-medium">{{ t('landing.orMonthly', { price: subs.displayPriceMonthly }) }}</div>
-              </div>
-            </div>
-            <p class="v2-body-soft mb-6">{{ t('landing.proBody') }}</p>
-            <ul class="space-y-3 mb-8 flex-1">
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-accent);">✦</span> {{ t('landing.proF1') }}</li>
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-accent);">✦</span> {{ t('landing.proF2') }}</li>
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-accent);">✦</span> {{ t('landing.proF3') }}</li>
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-accent);">✦</span> {{ t('landing.proF4') }}</li>
-              <li class="flex items-start gap-2 text-sm"><span style="color: var(--v2-accent);">✦</span> {{ t('landing.proF5') }}</li>
-            </ul>
-            <a href="/app?intent=pro" class="v2-btn v2-btn--primary v2-btn--block v2-btn--lg w-full">
-              {{ t('landing.proCta') }}
-            </a>
-          </div>
-        </div>
-        <p class="v2-caption text-center mt-6">{{ t('landing.pricingFinePrint') }}</p>
+      <!-- ── 4. Free ──────────────────────────────────────────────── -->
+      <!-- Subscription/Pro pricing removed 2026-07-07 — Ignia is free (moving
+           to a donations model, not a paid tier). -->
+      <section id="pricing" class="max-w-3xl mx-auto text-center pt-8">
+        <div class="section-badge" style="background: transparent; border: 1px solid var(--v2-rule);">{{ t('landing.freeStamp') }}</div>
+        <h2 class="v2-display mt-4">{{ t('landing.freeHeadline') }}</h2>
+        <p class="v2-body-soft mt-4 max-w-xl mx-auto">{{ t('landing.freeBody') }}</p>
+        <a href="/app" class="v2-btn v2-btn--primary v2-btn--lg mt-8 inline-flex">
+          {{ t('landing.freeCta') }}
+        </a>
       </section>
 
       <!-- ── 5. Comparisons + FAQ footer ─────────────────────────── -->

--- a/src/app/components/terms/terms.component.ts
+++ b/src/app/components/terms/terms.component.ts
@@ -48,6 +48,12 @@ import { UiCard } from '../ui/card.component';
         <h2 class="v2-h2 mt-6 mb-2" style="color: var(--v2-accent);">{{ t('terms.liabilityHeading') }}</h2>
         <p>{{ t('terms.liabilityBody') }}</p>
 
+        <h2 class="v2-h2 mt-6 mb-2" id="arbitration" style="color: var(--v2-accent);">{{ t('terms.arbHeading') }}</h2>
+        <p [innerHTML]="t('terms.arbBody')"></p>
+
+        <h2 class="v2-h2 mt-6 mb-2" style="color: var(--v2-accent);">{{ t('terms.lawHeading') }}</h2>
+        <p>{{ t('terms.lawBody') }}</p>
+
         <h2 class="v2-h2 mt-6 mb-2" id="subscriptions" style="color: var(--v2-accent);">{{ t('terms.subsHeading') }}</h2>
         <p [innerHTML]="t('terms.subsBody')"></p>
 

--- a/src/app/i18n/en.json
+++ b/src/app/i18n/en.json
@@ -994,7 +994,7 @@
     "logAria": "Log {{label}}, {{calories}} calories, {{protein}} grams protein"
   },
   "changelog": {
-    "backLink": "← back to macro log",
+    "backLink": "← back to Ignia",
     "stamp": "log",
     "section": "changelog",
     "titleLead": "Ship",
@@ -1014,7 +1014,7 @@
     "pageTitle": "Not found — Ignia"
   },
   "status": {
-    "backLink": "← back to macro log",
+    "backLink": "← back to Ignia",
     "stamp": "pulse",
     "section": "status",
     "titleLead": "System",
@@ -1069,7 +1069,7 @@
     "empty": "No entries match these filters."
   },
   "privacy": {
-    "backLink": "← back to macro log",
+    "backLink": "← back to Ignia",
     "stamp": "policy",
     "section": "privacy",
     "titleLead": "Privacy",
@@ -1126,13 +1126,13 @@
     "errorFallback": "Account deletion failed."
   },
   "terms": {
-    "backLink": "← back to macro log",
+    "backLink": "← back to Ignia",
     "stamp": "policy",
     "section": "terms of use",
     "titleLead": "Terms of",
     "titleEm": "use.",
     "pageTitle": "Terms — Ignia",
-    "lastUpdated": "last updated 2026-04-12 · short, because you shouldn't need a lawyer to read this.",
+    "lastUpdated": "last updated 2026-07-07 · short, because you shouldn't need a lawyer to read this.",
     "dealHeading": "The deal",
     "dealBody": "Ignia is a calorie, protein, and weight tracker with an AI coach. By signing in, you agree to use it as intended — a personal logging tool — and not to abuse it (scraping, reverse-engineering the webhook, attempting to access other users' data, etc).",
     "medHeading": "Not medical advice",
@@ -1142,7 +1142,11 @@
     "availHeading": "Availability + changes",
     "availBody": "Ignia runs on Google Cloud. We do our best to keep it up, but don't guarantee uptime. We may change features, pricing, or these terms — when we do, the footer's \"last updated\" date will change and meaningful changes will be announced in-app.",
     "liabilityHeading": "Liability",
-    "liabilityBody": "Ignia is provided \"as is.\" We're not liable for decisions you make based on its output, for lost data, or for any indirect harm from using the app. To the maximum extent allowed by law, our total liability to you is capped at whatever you've paid us in the last 12 months (which for most users is zero).",
+    "liabilityBody": "Ignia is provided \"as is\" and \"as available,\" without warranties of any kind, express or implied, including merchantability, fitness for a particular purpose, and non-infringement. We're not liable for decisions you make based on its output, for lost data, or for any indirect, incidental, or consequential harm from using the app. To the maximum extent allowed by law, our total liability to you is capped at whatever you've paid us in the last 12 months (which for most users is zero).",
+    "arbHeading": "Arbitration & class-action waiver",
+    "arbBody": "<strong>Please read this carefully — it affects your legal rights.</strong> If we have a dispute we can't resolve by email, you and the developer agree to resolve it through <strong>binding individual arbitration</strong> rather than in court, except that either of us may bring an eligible claim in small-claims court. <strong>You and the developer waive the right to a jury trial and the right to bring or participate in a class action or class-wide arbitration</strong> — disputes are handled only on an individual basis. Arbitration will be administered under the consumer rules of a recognized provider such as AAA or JAMS. You may opt out of this arbitration agreement within 30 days of first accepting these terms by emailing <a href='mailto:gabrielandresbermudez@gmail.com?subject=Arbitration%20opt-out' class='underline'>gabrielandresbermudez&#64;gmail.com</a> with the subject \"Arbitration opt-out.\" If any part of this section is unenforceable, the rest still applies, except a court (not an arbitrator) decides any claim that cannot be waived.",
+    "lawHeading": "Governing law + who runs Ignia",
+    "lawBody": "Ignia is operated by an individual developer, not a company. These terms are governed by the laws of the Commonwealth of Puerto Rico and applicable U.S. federal law, without regard to conflict-of-laws rules. Ignia is offered only in the United States and Puerto Rico and is not directed to users in the EU, UK, or EEA.",
     "subsHeading": "Subscriptions + auto-renewal",
     "subsBody": "Pro is offered monthly ($3/mo) or annual ($24/yr) via Stripe. A 7-day free trial comes with every first subscription. Plans <strong>auto-renew</strong> at the end of each billing cycle at the price shown on the subscribe card. You can cancel anytime from Settings → Subscription; cancellation takes effect at the end of the current paid period, and you keep Pro access until then. We email you a receipt for every renewal. If we change prices, we'll announce it in-app and honour your existing price through the current term.",
     "refundsHeading": "Refunds",

--- a/src/app/i18n/en.json
+++ b/src/app/i18n/en.json
@@ -128,6 +128,7 @@
     "termsLink": "read the terms",
     "pricingRule": "pricing",
     "freeStamp": "free",
+    "freeHeadline": "Free. The whole app.",
     "freePrice": "$0",
     "freeBody": "the full logging loop, forever. everything you need to answer \"how many calories do I have left?\" every day.",
     "freeF1": "unlimited manual entries, weight, fasting, measurements",

--- a/src/app/i18n/es-PR.json
+++ b/src/app/i18n/es-PR.json
@@ -994,7 +994,7 @@
     "logAria": "Registrar {{label}}, {{calories}} calorías, {{protein}} gramos de proteína"
   },
   "changelog": {
-    "backLink": "← volver a macro log",
+    "backLink": "← volver a Ignia",
     "stamp": "log",
     "section": "cambios",
     "titleLead": "Historial",
@@ -1014,7 +1014,7 @@
     "pageTitle": "No encontrado — Ignia"
   },
   "status": {
-    "backLink": "← volver a macro log",
+    "backLink": "← volver a Ignia",
     "stamp": "pulso",
     "section": "estado",
     "titleLead": "Estado",
@@ -1069,7 +1069,7 @@
     "empty": "Ninguna entrada coincide con estos filtros."
   },
   "privacy": {
-    "backLink": "← volver a macro log",
+    "backLink": "← volver a Ignia",
     "stamp": "política",
     "section": "privacidad",
     "titleLead": "Política",
@@ -1126,13 +1126,13 @@
     "errorFallback": "Falló la eliminación de la cuenta."
   },
   "terms": {
-    "backLink": "← volver a macro log",
+    "backLink": "← volver a Ignia",
     "stamp": "política",
     "section": "términos de uso",
     "titleLead": "Términos",
     "titleEm": "de uso.",
     "pageTitle": "Términos — Ignia",
-    "lastUpdated": "última actualización 2026-04-12 · corto, porque no deberías necesitar un abogado para leer esto.",
+    "lastUpdated": "última actualización 2026-07-07 · corto, porque no deberías necesitar un abogado para leer esto.",
     "dealHeading": "El acuerdo",
     "dealBody": "Ignia es un tracker de calorías, proteína y peso con un coach de IA. Al iniciar sesión, aceptas usarlo como está pensado — una herramienta personal de registro — y no abusar de él (scraping, hacer ingeniería inversa del webhook, intentar acceder a datos de otros usuarios, etc.).",
     "medHeading": "No es consejo médico",
@@ -1142,7 +1142,11 @@
     "availHeading": "Disponibilidad + cambios",
     "availBody": "Ignia corre en Google Cloud. Hacemos lo posible por mantenerlo disponible, pero no garantizamos uptime. Podemos cambiar funciones, precios o estos términos — cuando lo hagamos, la fecha de \"última actualización\" del pie de página cambiará y los cambios importantes se anunciarán dentro de la app.",
     "liabilityHeading": "Responsabilidad",
-    "liabilityBody": "Ignia se entrega \"tal cual.\" No somos responsables por decisiones que tomes basado en su salida, por datos perdidos, ni por ningún daño indirecto del uso de la app. En la medida máxima permitida por la ley, nuestra responsabilidad total hacia ti está limitada a lo que nos hayas pagado en los últimos 12 meses (que para la mayoría es cero).",
+    "liabilityBody": "Ignia se entrega \"tal cual\" y \"según disponibilidad,\" sin garantías de ningún tipo, expresas o implícitas, incluyendo comerciabilidad, idoneidad para un propósito particular y no infracción. No somos responsables por decisiones que tomes basado en su salida, por datos perdidos, ni por ningún daño indirecto, incidental o consecuente del uso de la app. En la medida máxima permitida por la ley, nuestra responsabilidad total hacia ti está limitada a lo que nos hayas pagado en los últimos 12 meses (que para la mayoría es cero).",
+    "arbHeading": "Arbitraje y renuncia a demandas colectivas",
+    "arbBody": "<strong>Lee esto con cuidado — afecta tus derechos legales.</strong> Si tenemos una disputa que no podemos resolver por correo, tú y el desarrollador acuerdan resolverla mediante <strong>arbitraje individual vinculante</strong> en vez de en corte, excepto que cualquiera puede llevar un reclamo elegible a la corte de reclamos menores. <strong>Tú y el desarrollador renuncian al derecho a un juicio con jurado y al derecho a presentar o participar en una demanda colectiva o arbitraje colectivo</strong> — las disputas se manejan solo de forma individual. El arbitraje se administrará bajo las reglas de consumidor de un proveedor reconocido como AAA o JAMS. Puedes optar por salir de este acuerdo de arbitraje dentro de los 30 días de aceptar estos términos por primera vez, escribiendo a <a href='mailto:gabrielandresbermudez@gmail.com?subject=Arbitration%20opt-out' class='underline'>gabrielandresbermudez&#64;gmail.com</a> con el asunto \"Arbitration opt-out.\" Si alguna parte de esta sección es inaplicable, el resto sigue vigente, excepto que una corte (no un árbitro) decide cualquier reclamo que no se pueda renunciar.",
+    "lawHeading": "Ley aplicable + quién opera Ignia",
+    "lawBody": "Ignia es operada por un desarrollador individual, no una empresa. Estos términos se rigen por las leyes del Estado Libre Asociado de Puerto Rico y la ley federal de EE. UU. aplicable, sin considerar reglas de conflicto de leyes. Ignia se ofrece solo en Estados Unidos y Puerto Rico y no está dirigida a usuarios en la UE, el Reino Unido o el EEE.",
     "subsHeading": "Suscripciones + renovación automática",
     "subsBody": "Pro se ofrece mensual ($3/mes) o anual ($24/año) vía Stripe. Toda primera suscripción incluye una prueba gratuita de 7 días. Los planes se <strong>renuevan automáticamente</strong> al final de cada ciclo al precio mostrado en la tarjeta de suscripción. Puedes cancelar en cualquier momento desde Ajustes → Suscripción; la cancelación surte efecto al final del período ya pagado y conservas Pro hasta entonces. Te enviamos un recibo por cada renovación. Si cambiamos precios, lo anunciaremos en la app y respetaremos tu precio actual hasta el fin del término vigente.",
     "refundsHeading": "Reembolsos",

--- a/src/app/i18n/es-PR.json
+++ b/src/app/i18n/es-PR.json
@@ -128,6 +128,7 @@
     "termsLink": "lee los términos",
     "pricingRule": "precios",
     "freeStamp": "gratis",
+    "freeHeadline": "Gratis. Toda la app.",
     "freePrice": "$0",
     "freeBody": "el ciclo completo de registro, para siempre. todo lo que necesitas para responder \"¿cuántas calorías me quedan?\" cada día.",
     "freeF1": "entradas manuales ilimitadas, peso, ayuno, medidas",

--- a/src/app/services/firebase.service.ts
+++ b/src/app/services/firebase.service.ts
@@ -289,7 +289,10 @@ export interface ProfileFields {
  * and what every store/component consumes.
  */
 export interface Profile extends Partial<ProfileFields> {
-  email: string;
+  /** Legacy-only: no longer written on new profiles (PII minimization,
+   *  2026-07-07). Present on pre-existing docs; email otherwise lives in
+   *  Firebase Auth. Never relied on by the client (all UI reads Auth). */
+  email?: string;
   createdAt: Date;
   lastSeenAt: Date;
   profileCompleted: boolean;
@@ -377,8 +380,10 @@ export class FirebaseService implements LedgerPort {
     const now = Timestamp.now();
 
     if (existing === null) {
+      // PII minimization (2026-07-07): the email is NOT persisted to the
+      // profile doc — it lives only in Firebase Auth. Server-side email
+      // features (welcome, weekly digest) fetch it from Auth by uid.
       const initial: UserProfileDoc = {
-        email: user.email ?? '',
         createdAt: now,
         lastSeenAt: now,
         profileCompleted: false,


### PR DESCRIPTION
Pivot: LLC dropped (foreign-LLC-in-PR fees vs \$0 income) → Ignia ships as a sole individual.

## Legal (web, en + es-PR parity)
- **Arbitration + class-action/jury waiver** (30-day opt-out) — was missing; memory's highest-value consumer clause.
- **Governing law** section: PR + US federal; US+PR only, not directed to EU/UK/EEA.
- Expanded warranty disclaimer; operator named as an individual. Date bumped; stale "macro log" brand fixed.

## PII minimization
- Mobile Apple sign-in drops `FULL_NAME` scope (EMAIL only) — name was never used.
- **Email no longer persisted to the Firestore `users/{uid}` doc** — lives only in Firebase Auth, so the health-data store is keyed by opaque uid. Rules no longer require email (still allowed for legacy docs); welcome-email / weekly-digest / public-profile fetch it from Auth by uid.

## Docs
- `MOBILE_RELEASE.md` + `APP_STORE_LISTING.md`: Individual store accounts, Windows/EAS-free-tier build economics, cut progress-photos row.

## Verification
- functions `tsc` clean; `npm run test:rules` **53/53** (incl. new no-email test).
- **Already deployed to prod** (rules+functions, then hosting) from this branch — this PR brings `main` in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)