### PR TITLE
refactor(core): share the Firestore write path between both frontends

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,9 +108,25 @@ add a term when a real ambiguity exists, not preemptively.
   un-barreled `workout.ts` read-model types and do the field-copy + `toDate`
   only; the web adapter post-applies `normalizeClusterGroups` where mobile does
   not, so that one asymmetry stays at the call site, not in the shared mapper.
+- **Firestore writers** — The shared domain→doc **write-path** serializers in
+  `packages/core/src/firestore-writers.ts`, the twin of the mappers above. Every
+  stored shape both apps write is assembled there (`toLogDoc`/`toLogPatch`,
+  `toPresetDoc`, `toCustomFoodDoc`, `toMeasurementDoc`/`Patch`, `toExerciseDoc`,
+  `toTemplateDoc`/`Patch`, `toSessionDoc`/`Patch`) plus `BATCH_CHUNK`, so a new
+  field lands once and neither adapter can drift past `firestore.rules`.
+  Where a read could recognize a `Timestamp` structurally, a write must
+  **produce** SDK values, so each adapter injects a **DocCodec**
+  (`{ timestamp(d), remove() }` → `Timestamp.fromDate` / `deleteField`) — the
+  same injection `prune-undefined` uses for `isOpaque`. Two conventions: create
+  paths return a typed doc while **patch** paths return a loose record (a
+  sentinel-or-value field can't be typed honestly), and `now` is always a
+  parameter, never an SDK `now()` call, so stamps stay assertable. The adapters
+  keep all I/O, the collection paths, their `pruneUndefined` binding, and
+  `mergeExercises` (a rewrite rule over fetched docs, not a serializer).
 - **Legacy log fields** — `liftCompleted` and `cardioCompleted` exist on
   historic docs. New writes only set `exerciseCompleted`. Aggregation
-  treats any of the three as "exercised that day".
+  treats any of the three as "exercised that day". `toLogPatch` removes both on
+  every edit, so any row that gets touched migrates forward.
 
 ## Time windows over logs
 
@@ -265,8 +281,16 @@ These three windows look similar and are NOT interchangeable. See
   **Firebase Storage** at `users/{uid}/photos/{date}.jpg`. No longer written by
   either app; Storage is deny-all and account deletion still purges any legacy
   `users/{uid}/photos/` bytes (`functions/src/gdpr.ts`).
-- **Water** — Stored in ml under `users/{uid}/dailyWater/{YYYY-MM-DD}`.
-  Capped 0–20,000 ml at write time.
+- **Water** — Stored in **US fluid ounces** under
+  `users/{uid}/dailyWater/{YYYY-MM-DD}` as `{ flOz }` (the app is imperial
+  throughout). Docs written before the 2026-06 unit migration carry `{ ml }`;
+  reads fall back to converting them, so an unrewritten legacy doc still
+  renders. Every write clamps to `[0, WATER_MAX_FLOZ]` (676 fl oz, ~5 gal,
+  mirrored in `firestore.rules`) via `clampWaterFlOz` in
+  `packages/core/src/health-mapping.ts` — the canonical bound, applied by both
+  Firestore adapters, the in-memory adapter, and `BodyMetricStore`. Sleep is
+  the same pattern: `{ hours }` per date, `clampSleepHours` → `[0, 24]` snapped
+  to the half hour.
 - **FastWindow** — Active fasting window, target 16h. Owned by
   `FastingStore`; profile carries `fastStartedAt`. `isFasting()` is
   computed from the start time being non-null.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — what is true right now
 
-**Updated:** 2026-07-29 · **Owns:** current state only. Not history (`CHANGELOG.md`),
+**Updated:** 2026-07-31 · **Owns:** current state only. Not history (`CHANGELOG.md`),
 not rationale (`docs/adr/`), not vocabulary (`CONTEXT.md`).
 
 If a statement here conflicts with any other file in this repo, **this file wins** —
@@ -18,7 +18,7 @@ work because a plan doc was read as a status doc.
 | Web PWA `ignia.fit` | **Live**, bilingual (EN + es-PR), **105** prerendered pages (en 52 / es 53), 114-URL sitemap | `npm run build` prints both counts |
 | iOS App Store | **1.0.0, build 7** (uploaded 2026-07-20, `READY_FOR_SALE`), from commit `168e0394` | ASC command below |
 | iOS 1.1.0 | **Metadata shell only** — `PREPARE_FOR_SUBMISSION`, **no binary attached** | ASC command below |
-| Android / Play | **Not launched.** No Play account, no device, no closed-test cohort | — |
+| Android / Play | **Not launched.** Play Console account exists, **developer verification complete** and `fit.ignia.app` **package name registered** (both 2026-07-31), proven with an APK signed by `apps/mobile/credentials/dev.keystore` (alias `macrolog-dev`, SHA-256 `75:4B:03:19:…:F6:D8`) — **that keystore is now load-bearing app identity; it is git-ignored and exists in one place**. App entry created (`4975181896468259775`), no AAB, no closed-test cohort yet. **Personal developer account → production access requires closed testing with 12 testers opted in 14 CONTINUOUS days** ([policy](https://support.google.com/googleplay/android-developer/answer/14151465)); the clock cannot start until a build is in a closed track, so the AAB is the critical path, not the paperwork | Play Console → Android developer verification → Package names |
 | Cloud Functions / rules | Deployed, project `fitness-tracker-gb-1775407101` | `firebase deploy --only functions --dry-run` |
 
 **The `1.1.0` trap.** `app.json` says 1.1.0 and ASC has a 1.1.0 version page, but
@@ -98,7 +98,11 @@ cd apps/mobile && npx eas-cli build:list --platform ios --limit 5   # what exist
 | #46 | Read the watch layouts on a simulator | **a Mac with Xcode** (currently: borrow one) |
 | #47 | Compile the generated watch targets in Xcode | **a Mac with Xcode**; branch `probe/watch-compile-47` stages it |
 | — | App Store screenshots | owner, on device (`store-assets/README.md`) |
-| — | Play launch | Play account + 12 testers × 14 consecutive days |
+| — | Play launch — **first AAB** | `bundleRelease` dies on Windows `MAX_PATH`: the `react-native-keyboard-controller` C++ object path is ~355 chars. `LongPathsEnabled=1` is set but **needs a reboot** to take effect; if it still fails after that, ninja itself is the cap → build on EAS. Signing: `credentials/dev.keystore` as upload key |
+| — | Play launch — **12 testers × 14 consecutive days** | owner recruiting. Personal account, so production access is gated on it. Clock cannot start until an AAB is in a closed track — **this is the critical path** |
+| — | Play launch — **Data safety form** | steps 1–2 saved as draft; steps 3–5 unanswered. Declare: Personal info (Name, Email, User IDs) + Health and fitness (Health info, Fitness info); collected, **not shared**, required, purpose App functionality + Account management. Nothing else — no analytics/crash SDK on mobile, notifications are local-only, photo-scan is flag-off |
+| — | Play launch — **delete-account URL** | set to `ignia.fit/privacy`; Google requires that page to prominently show the deletion steps. Unverified — either confirm or add the section |
+| — | Play launch — **store listing graphics** | feature graphic 1024×500 does not exist; the iOS screenshots are 1320×2868 (2.17:1) and exceed Play's 2:1 cap, so they cannot be reused as-is |
 
 **Apple glanceable surfaces (map #31).** 13 of its 16 tickets are **closed** — the
 transport, staleness, layouts, tap targets, review surface and sign-out privacy are

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -25,8 +25,35 @@ const ALIASES = [
   ['@', path.resolve(__dirname, 'src')],
 ];
 
+// Same workspace-root trap, one layer up — this one kills the ANDROID RELEASE
+// BUILD outright. Gradle bundles by running Expo CLI from `apps/mobile` with a
+// RELATIVE `--entry-file index.js` (the RN Gradle plugin relativizes the
+// absolute path `expo/scripts/resolveAppEntry` hands it against `react.root`).
+// Expo then resolves that against Metro's SERVER root — the workspace — so it
+// looks for `Z:\macro-app\index.js` and dies with "Unable to resolve module
+// ./index.js". Debug and Expo Go never hit it; only the release bundle does,
+// which is why a QR-code smoke test on a device proves nothing here.
+// `main` is a custom `index.js` on purpose (it registers the Android widget
+// task handler before React mounts — see AGENTS.md / WIDGET.md), so the entry
+// cannot be moved to `expo-router/entry` to dodge this.
+// Do NOT "fix" this by setting `react.root` to the workspace in build.gradle:
+// that moves Expo's project root too, THIS config stops loading, and the
+// `@/…` aliases above vanish (build fails on `@/lib/widget` instead).
+// Matching only an origin of exactly the workspace root keeps the ordinary
+// `require('./index.js')` inside hoisted node_modules packages untouched.
+const WORKSPACE_ROOT = path.resolve(__dirname, '../..');
+const APP_ENTRY = path.resolve(__dirname, 'index.js');
+
 const HK = '@kingstinct/react-native-healthkit';
 config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (
+    moduleName === './index.js' &&
+    typeof context.originModulePath === 'string' &&
+    path.resolve(context.originModulePath) === WORKSPACE_ROOT
+  ) {
+    return context.resolveRequest(context, APP_ENTRY, platform);
+  }
+
   for (const [prefix, target] of ALIASES) {
     if (moduleName === prefix || moduleName.startsWith(`${prefix}/`)) {
       const rest = moduleName.slice(prefix.length).replace(/^\//, '');

--- a/apps/mobile/src/lib/ledger.ts
+++ b/apps/mobile/src/lib/ledger.ts
@@ -28,16 +28,31 @@ import {
   type RefineTargetsSubmission,
   type UnitSystem,
   type WeeklyReport,
+  type DocCodec,
+  type MeasurementInput,
   ACTIVE_ENERGY_MAX_KCAL,
+  BATCH_CHUNK,
   STEPS_MAX,
   clampCutPace,
+  clampSleepHours,
+  clampWaterFlOz,
   localDateKey,
   oldestFirst,
   pruneUndefined as pruneUndefinedCore,
   toCustomFood,
+  toCustomFoodDoc,
   toDailyLog,
   toDomainProfile,
+  toExerciseDoc,
+  toLogDoc,
+  toLogPatch,
   toMeasurement,
+  toMeasurementDoc,
+  toPresetDoc,
+  toSessionDoc,
+  toSessionPatch,
+  toTemplateDoc,
+  toTemplatePatch,
   toWeeklyReport,
   // Shared workout doc→domain mappers (arch review E). Mobile does NOT
   // normalize cluster groups (the web adapter does), so it uses these directly.
@@ -74,6 +89,15 @@ const reportsCol = (uid: string) => collection(db, 'users', uid, 'reports');
 const userDoc = (uid: string) => doc(db, 'users', uid);
 
 type Unsub = () => void;
+
+/** The two SDK values the shared writers can't construct themselves, bound to
+ *  this edge's Firestore SDK once (see `@macrolog/core/firestore-writers`).
+ *  The PWA adapter binds the identical pair against @angular/fire's SDK copy,
+ *  which is why both apps emit byte-identical docs. */
+const CODEC: DocCodec<Timestamp> = {
+  timestamp: (d) => Timestamp.fromDate(d),
+  remove: () => deleteField(),
+};
 
 /** Live-subscribe to the latest `count` log rows, delivered OLDEST-FIRST
  *  (matches the ledger seam contract). Doc → domain mapping + the oldest-first
@@ -112,57 +136,32 @@ export function subscribeLatestReport(
   );
 }
 
-function logData(entry: LogEntry): Record<string, unknown> {
-  const data: Record<string, unknown> = {
-    calories: entry.calories,
-    timestamp: Timestamp.fromDate(entry.timestamp ?? new Date()),
-  };
-  if (entry.weight != null) data['weight'] = entry.weight;
-  if (entry.protein != null) data['protein'] = entry.protein;
-  if (entry.carbs != null) data['carbs'] = entry.carbs;
-  if (entry.fat != null) data['fat'] = entry.fat;
-  if (entry.exerciseCompleted) data['exerciseCompleted'] = true;
-  if (entry.mealLabel) data['mealLabel'] = entry.mealLabel;
-  if (entry.mealType) data['mealType'] = entry.mealType;
-  return data;
-}
-
 export async function addLog(uid: string, entry: LogEntry): Promise<string> {
-  const ref = await addDoc(logsCol(uid), logData(entry));
+  const ref = await addDoc(logsCol(uid), toLogDoc(entry, CODEC));
   return ref.id;
 }
 
 export async function updateLog(uid: string, id: string, entry: LogEntry): Promise<void> {
-  const data: Record<string, unknown> = {
-    calories: entry.calories,
-    protein: entry.protein != null ? entry.protein : deleteField(),
-    carbs: entry.carbs != null ? entry.carbs : deleteField(),
-    fat: entry.fat != null ? entry.fat : deleteField(),
-    exerciseCompleted: entry.exerciseCompleted ? true : deleteField(),
-    liftCompleted: deleteField(),
-    cardioCompleted: deleteField(),
-    mealLabel: entry.mealLabel ? entry.mealLabel : deleteField(),
-    mealType: entry.mealType ? entry.mealType : deleteField(),
-  };
-  if (entry.weight != null) data['weight'] = entry.weight;
-  if (entry.timestamp != null) data['timestamp'] = Timestamp.fromDate(entry.timestamp);
-  await updateDoc(logDoc(uid, id), data);
+  await updateDoc(logDoc(uid, id), toLogPatch(entry, CODEC));
 }
 
 export async function deleteLog(uid: string, id: string): Promise<void> {
   await deleteDoc(logDoc(uid, id));
 }
 
-/** Bulk-import parsed LogEntry rows in ≤450-op batches (Firestore's 500-write
- *  cap). Returns the number written. Mirrors FirestoreLedgerCore.importLogs. */
+/** Bulk-import parsed LogEntry rows in ≤BATCH_CHUNK-op batches (Firestore's
+ *  500-write cap). Returns the number written. Mirrors
+ *  FirestoreLedgerCore.importLogs — same chunk size, same row serializer. */
 export async function importLogs(uid: string, entries: readonly LogEntry[]): Promise<number> {
   const coll = logsCol(uid);
   let written = 0;
-  for (let i = 0; i < entries.length; i += 450) {
+  for (let i = 0; i < entries.length; i += BATCH_CHUNK) {
     const batch = writeBatch(db);
-    for (const entry of entries.slice(i, i + 450)) batch.set(doc(coll), logData(entry));
+    for (const entry of entries.slice(i, i + BATCH_CHUNK)) {
+      batch.set(doc(coll), toLogDoc(entry, CODEC));
+    }
     await batch.commit();
-    written += Math.min(450, entries.length - i);
+    written += Math.min(BATCH_CHUNK, entries.length - i);
   }
   return written;
 }
@@ -238,7 +237,7 @@ export function subscribeDailyWater(
 }
 
 export async function setDailyWater(uid: string, dateKey: string, flOz: number): Promise<void> {
-  await setDoc(waterDoc(uid, dateKey), { flOz: Math.max(0, Math.min(676, Math.round(flOz))) });
+  await setDoc(waterDoc(uid, dateKey), { flOz: clampWaterFlOz(flOz) });
 }
 
 // ─── Daily sleep ────────────────────────────────────────────────
@@ -266,7 +265,7 @@ export function subscribeDailySleep(
 }
 
 export async function setDailySleep(uid: string, dateKey: string, hours: number): Promise<void> {
-  await setDoc(sleepDoc(uid, dateKey), { hours: Math.max(0, Math.min(24, Math.round(hours * 2) / 2)) });
+  await setDoc(sleepDoc(uid, dateKey), { hours: clampSleepHours(hours) });
 }
 
 // ─── Daily activity (import-only) ───────────────────────────────
@@ -547,11 +546,7 @@ export function subscribePresets(
 }
 
 export async function addPreset(uid: string, preset: Omit<MealPreset, 'id'>): Promise<string> {
-  const data: Record<string, unknown> = { name: preset.name, calories: preset.calories };
-  if (preset.protein != null) data['protein'] = preset.protein;
-  if (preset.carbs != null) data['carbs'] = preset.carbs;
-  if (preset.fat != null) data['fat'] = preset.fat;
-  const ref = await addDoc(presetsCol(uid), data);
+  const ref = await addDoc(presetsCol(uid), toPresetDoc(preset));
   return ref.id;
 }
 
@@ -585,19 +580,7 @@ export async function addCustomFood(
   food: Omit<CustomFood, 'id'>,
   id?: string | null,
 ): Promise<string> {
-  const data: Record<string, unknown> = {
-    name: food.name,
-    servingSize: food.servingSize,
-    servingUnit: food.servingUnit,
-    calories: food.calories,
-    source: food.source,
-    createdAt: Timestamp.fromDate(food.createdAt),
-  };
-  if (food.brand != null) data['brand'] = food.brand;
-  if (food.barcode != null) data['barcode'] = food.barcode;
-  if (food.protein != null) data['protein'] = food.protein;
-  if (food.carbs != null) data['carbs'] = food.carbs;
-  if (food.fat != null) data['fat'] = food.fat;
+  const data = toCustomFoodDoc(food, CODEC);
   if (id) {
     await setDoc(customFoodDoc(uid, id), data);
     return id;
@@ -624,20 +607,8 @@ export function subscribeMeasurements(
   return onSnapshot(q, (snap) => cb(snap.docs.map((d) => toMeasurement(d.id, d.data()))), onError);
 }
 
-type MeasurementInput = Omit<Measurement, 'id' | 'date'>;
-
-function measurementData(entry: MeasurementInput): Record<string, unknown> {
-  const data: Record<string, unknown> = {};
-  if (entry.waist != null) data['waist'] = entry.waist;
-  if (entry.chest != null) data['chest'] = entry.chest;
-  if (entry.bicep != null) data['bicep'] = entry.bicep;
-  if (entry.hip != null) data['hip'] = entry.hip;
-  if (entry.neck != null) data['neck'] = entry.neck;
-  return data;
-}
-
 export async function addMeasurement(uid: string, entry: MeasurementInput): Promise<string> {
-  const ref = await addDoc(measurementsCol(uid), { timestamp: Timestamp.now(), ...measurementData(entry) });
+  const ref = await addDoc(measurementsCol(uid), toMeasurementDoc(entry, CODEC));
   return ref.id;
 }
 
@@ -681,15 +652,7 @@ export function subscribeExercises(
 }
 
 export async function addExercise(uid: string, draft: ExerciseDraft): Promise<string> {
-  const data = pruneUndefined({
-    name: draft.name,
-    muscles: draft.muscles ?? [],
-    defaultCues: draft.defaultCues ?? [],
-    logStyle: draft.logStyle,
-    seedKey: draft.seedKey,
-    createdAt: Timestamp.now(),
-  });
-  const ref = await addDoc(exercisesCol(uid), data);
+  const ref = await addDoc(exercisesCol(uid), pruneUndefined(toExerciseDoc(draft, CODEC)));
   return ref.id;
 }
 
@@ -708,7 +671,7 @@ export async function deleteExercise(uid: string, id: string): Promise<void> {
 /** Merge catalog exercise `fromId` (victim) into `toId` (survivor): rewrite
  *  every session and template that references the victim to point at the
  *  survivor (snapshotting the survivor's name), then delete the victim doc.
- *  Mirrors FirestoreLedgerCore.mergeExercises — batched in chunks of 450. */
+ *  Mirrors FirestoreLedgerCore.mergeExercises — batched in BATCH_CHUNK ops. */
 export async function mergeExercises(uid: string, fromId: string, toId: string): Promise<void> {
   if (fromId === toId) return;
   const survivor = await getDoc(exerciseDoc(uid, toId));
@@ -733,9 +696,9 @@ export async function mergeExercises(uid: string, fromId: string, toId: string):
     if (exercises) ops.push({ ref: d.ref, exercises });
   }
 
-  for (let i = 0; i < ops.length; i += 450) {
+  for (let i = 0; i < ops.length; i += BATCH_CHUNK) {
     const batch = writeBatch(db);
-    for (const op of ops.slice(i, i + 450)) {
+    for (const op of ops.slice(i, i + BATCH_CHUNK)) {
       batch.update(op.ref, pruneUndefined({ exercises: op.exercises, updatedAt: Timestamp.now() }));
     }
     await batch.commit();
@@ -760,34 +723,15 @@ export function subscribeTemplates(
 }
 
 export async function addTemplate(uid: string, draft: TemplateDraft): Promise<string> {
-  const now = Timestamp.now();
-  const data = pruneUndefined({
-    name: draft.name,
-    notes: draft.notes,
-    restMiniSec: draft.restMiniSec,
-    restClusterSec: draft.restClusterSec,
-    exercises: draft.exercises ?? [],
-    seedKey: draft.seedKey,
-    createdAt: now,
-    updatedAt: now,
-  });
-  const ref = await addDoc(templatesCol(uid), data);
+  const ref = await addDoc(templatesCol(uid), pruneUndefined(toTemplateDoc(draft, CODEC)));
   return ref.id;
 }
 
 export async function updateTemplate(uid: string, id: string, draft: TemplateDraft): Promise<void> {
   // Full overwrite of mutable fields + bump updatedAt; createdAt untouched by
-  // merge. A merge-update of `exercises` would union arrays, so write the
-  // whole template doc (createAt stays, no `exercises` field omitted).
-  const data = pruneUndefined({
-    name: draft.name,
-    notes: draft.notes,
-    restMiniSec: draft.restMiniSec,
-    restClusterSec: draft.restClusterSec,
-    exercises: draft.exercises ?? [],
-    seedKey: draft.seedKey,
-    updatedAt: Timestamp.now(),
-  });
+  // merge. A merge-update of `exercises` would union arrays, so the patch
+  // carries the whole template doc.
+  const data = pruneUndefined(toTemplatePatch(draft, CODEC));
   await setDoc(templateDoc(uid, id), data, { merge: true });
 }
 
@@ -796,20 +740,8 @@ export async function deleteTemplate(uid: string, id: string): Promise<void> {
 }
 
 // ── Sessions ──
-/** Serialize a SessionDraft to the stored doc shape (date → `timestamp`). */
-function sessionData(draft: Partial<SessionDraft>): Record<string, unknown> {
-  const data: Record<string, unknown> = {};
-  if (draft.status !== undefined) data['status'] = draft.status;
-  if (draft.templateId !== undefined) data['templateId'] = draft.templateId;
-  if (draft.templateName !== undefined) data['templateName'] = draft.templateName;
-  if (draft.date !== undefined) data['timestamp'] = Timestamp.fromDate(draft.date);
-  if (draft.bodyweight !== undefined) data['bodyweight'] = draft.bodyweight;
-  if (draft.sleepHours !== undefined) data['sleepHours'] = draft.sleepHours;
-  if (draft.durationMin !== undefined) data['durationMin'] = draft.durationMin;
-  if (draft.exercises !== undefined) data['exercises'] = draft.exercises;
-  if (draft.nextNotes !== undefined) data['nextNotes'] = draft.nextNotes;
-  return data;
-}
+// The domain calls it `date`; the stored field is `timestamp`. Both the
+// create and the sparse live-update shapes come from @macrolog/core.
 
 /** One-shot read of the in-progress session, if any (status == 'active'). */
 export async function getActiveSession(uid: string): Promise<WorkoutSession | null> {
@@ -833,9 +765,7 @@ export function subscribeRecentSessions(
 }
 
 export async function startSession(uid: string, draft: SessionDraft): Promise<string> {
-  const now = Timestamp.now();
-  const data = pruneUndefined({ ...sessionData(draft), createdAt: now, updatedAt: now });
-  const ref = await addDoc(sessionsCol(uid), data);
+  const ref = await addDoc(sessionsCol(uid), pruneUndefined(toSessionDoc(draft, CODEC)));
   return ref.id;
 }
 
@@ -844,7 +774,7 @@ export async function updateSession(
   id: string,
   patch: Partial<SessionDraft>,
 ): Promise<void> {
-  const data = pruneUndefined({ ...sessionData(patch), updatedAt: Timestamp.now() });
+  const data = pruneUndefined(toSessionPatch(patch, CODEC));
   await setDoc(sessionDoc(uid, id), data, { merge: true });
 }
 

--- a/packages/core/src/firestore-writers.test.ts
+++ b/packages/core/src/firestore-writers.test.ts
@@ -1,0 +1,326 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BATCH_CHUNK,
+  type DocCodec,
+  toCustomFoodDoc,
+  toExerciseDoc,
+  toLogDoc,
+  toLogPatch,
+  toMeasurementDoc,
+  toMeasurementPatch,
+  toPresetDoc,
+  toSessionDoc,
+  toSessionPatch,
+  toTemplateDoc,
+  toTemplatePatch,
+} from './firestore-writers';
+
+/**
+ * A stand-in for the SDK values the real adapters inject. Both are plain,
+ * comparable values so a test can assert on the emitted doc directly — which
+ * is the whole reason the codec is a parameter rather than an SDK import.
+ */
+const REMOVE = '<delete>';
+const codec: DocCodec<{ ts: number }> = {
+  timestamp: (d) => ({ ts: d.getTime() }),
+  remove: () => REMOVE,
+};
+
+const NOW = new Date('2026-07-30T12:00:00Z');
+const stamp = { ts: NOW.getTime() };
+
+describe('toLogDoc', () => {
+  it('emits calories + timestamp and omits every unset optional', () => {
+    expect(toLogDoc({ calories: 500 }, codec, NOW)).toEqual({
+      calories: 500,
+      timestamp: stamp,
+    });
+  });
+
+  it('carries every provided field', () => {
+    const at = new Date('2026-07-29T08:30:00Z');
+    expect(
+      toLogDoc(
+        {
+          calories: 620,
+          weight: 181.4,
+          protein: 44,
+          carbs: 61,
+          fat: 18,
+          exerciseCompleted: true,
+          mealLabel: 'Greek yogurt',
+          mealType: 'breakfast',
+          timestamp: at,
+        },
+        codec,
+        NOW,
+      ),
+    ).toEqual({
+      calories: 620,
+      timestamp: { ts: at.getTime() },
+      weight: 181.4,
+      protein: 44,
+      carbs: 61,
+      fat: 18,
+      exerciseCompleted: true,
+      mealLabel: 'Greek yogurt',
+      mealType: 'breakfast',
+    });
+  });
+
+  it('keeps a zero macro but drops an empty meal label', () => {
+    // 0 is real data (`!= null`); '' is the UI's "not entered" (falsy check).
+    const doc = toLogDoc({ calories: 0, protein: 0, mealLabel: '' }, codec, NOW);
+    expect(doc.protein).toBe(0);
+    expect('mealLabel' in doc).toBe(false);
+  });
+
+  it('never writes exerciseCompleted: false — the key is simply absent', () => {
+    expect('exerciseCompleted' in toLogDoc({ calories: 1, exerciseCompleted: false }, codec, NOW))
+      .toBe(false);
+  });
+
+  it('stamps `now` only when the entry carries no timestamp', () => {
+    expect(toLogDoc({ calories: 1 }, codec, NOW).timestamp).toEqual(stamp);
+  });
+});
+
+describe('toLogPatch', () => {
+  it('removes each cleared macro instead of leaving the stored value', () => {
+    const patch = toLogPatch({ calories: 300 }, codec);
+    expect(patch).toMatchObject({
+      calories: 300,
+      protein: REMOVE,
+      carbs: REMOVE,
+      fat: REMOVE,
+      exerciseCompleted: REMOVE,
+      mealLabel: REMOVE,
+      mealType: REMOVE,
+    });
+  });
+
+  it('always removes the legacy completion fields, migrating the row on edit', () => {
+    const patch = toLogPatch({ calories: 300, exerciseCompleted: true }, codec);
+    expect(patch['liftCompleted']).toBe(REMOVE);
+    expect(patch['cardioCompleted']).toBe(REMOVE);
+    expect(patch['exerciseCompleted']).toBe(true);
+  });
+
+  it('omits timestamp and weight rather than removing them', () => {
+    // Both are owned elsewhere (the row keeps its instant; weight lives in
+    // dailyWeights), so "not provided" must mean "leave alone", not "delete".
+    const patch = toLogPatch({ calories: 300 }, codec);
+    expect('timestamp' in patch).toBe(false);
+    expect('weight' in patch).toBe(false);
+  });
+
+  it('sets timestamp and weight when provided', () => {
+    const at = new Date('2026-01-02T03:04:05Z');
+    const patch = toLogPatch({ calories: 300, weight: 179, timestamp: at }, codec);
+    expect(patch['timestamp']).toEqual({ ts: at.getTime() });
+    expect(patch['weight']).toBe(179);
+  });
+});
+
+describe('toPresetDoc', () => {
+  it('keeps the required pair and drops unset macros', () => {
+    expect(toPresetDoc({ name: 'Shake', calories: 240 })).toEqual({
+      name: 'Shake',
+      calories: 240,
+    });
+  });
+
+  it('carries provided macros', () => {
+    expect(toPresetDoc({ name: 'Shake', calories: 240, protein: 30, carbs: 12, fat: 5 })).toEqual({
+      name: 'Shake',
+      calories: 240,
+      protein: 30,
+      carbs: 12,
+      fat: 5,
+    });
+  });
+});
+
+describe('toCustomFoodDoc', () => {
+  const base = {
+    name: 'Skyr',
+    servingSize: 150,
+    servingUnit: 'g' as const,
+    calories: 96,
+    source: 'barcode' as const,
+    createdAt: NOW,
+  };
+
+  it('maps createdAt through the codec and omits unset optionals', () => {
+    expect(toCustomFoodDoc(base, codec)).toEqual({ ...base, createdAt: stamp });
+  });
+
+  it('carries brand, barcode and macros when present', () => {
+    expect(
+      toCustomFoodDoc({ ...base, brand: 'Siggi', barcode: '0123456789012', protein: 17 }, codec),
+    ).toMatchObject({ brand: 'Siggi', barcode: '0123456789012', protein: 17 });
+  });
+
+  it('uses the food\'s own createdAt, not the write instant', () => {
+    const authored = new Date('2025-12-25T00:00:00Z');
+    expect(toCustomFoodDoc({ ...base, createdAt: authored }, codec).createdAt).toEqual({
+      ts: authored.getTime(),
+    });
+  });
+});
+
+describe('measurements', () => {
+  it('stamps the doc with the write instant', () => {
+    expect(toMeasurementDoc({ waist: 34 }, codec, NOW)).toEqual({ timestamp: stamp, waist: 34 });
+  });
+
+  it('omits unmeasured sites on create', () => {
+    const doc = toMeasurementDoc({ waist: 34 }, codec, NOW);
+    for (const site of ['chest', 'bicep', 'hip', 'neck']) expect(site in doc).toBe(false);
+  });
+
+  it('removes cleared sites on edit, and leaves the row\'s date alone', () => {
+    const patch = toMeasurementPatch({ waist: 34, neck: 15 }, codec);
+    expect(patch).toEqual({
+      waist: 34,
+      chest: REMOVE,
+      bicep: REMOVE,
+      hip: REMOVE,
+      neck: 15,
+    });
+    expect('timestamp' in patch).toBe(false);
+  });
+});
+
+describe('toExerciseDoc', () => {
+  it('defaults both arrays so the doc always satisfies isValidExercise', () => {
+    expect(toExerciseDoc({ name: 'Row' }, codec, NOW)).toEqual({
+      name: 'Row',
+      muscles: [],
+      defaultCues: [],
+      createdAt: stamp,
+    });
+  });
+
+  it('carries muscles, cues, logStyle and seedKey', () => {
+    expect(
+      toExerciseDoc(
+        {
+          name: 'Plank',
+          muscles: ['core'],
+          defaultCues: ['Brace'],
+          logStyle: 'time',
+          seedKey: 'plank',
+        },
+        codec,
+        NOW,
+      ),
+    ).toEqual({
+      name: 'Plank',
+      muscles: ['core'],
+      defaultCues: ['Brace'],
+      logStyle: 'time',
+      seedKey: 'plank',
+      createdAt: stamp,
+    });
+  });
+});
+
+describe('templates', () => {
+  const draft = { name: 'Push A', exercises: [] };
+
+  it('stamps createdAt and updatedAt identically on create', () => {
+    const doc = toTemplateDoc(draft, codec, NOW);
+    expect(doc.createdAt).toEqual(stamp);
+    expect(doc.updatedAt).toEqual(doc.createdAt);
+  });
+
+  it('never writes createdAt on edit — a merge would reset the row\'s age', () => {
+    const patch = toTemplatePatch(draft, codec, NOW);
+    expect('createdAt' in patch).toBe(false);
+    expect(patch['updatedAt']).toEqual(stamp);
+  });
+
+  it('rewrites the whole exercise list rather than patching into it', () => {
+    // A merged array would union with the stored one, so the full list ships
+    // on every edit — including an emptied one.
+    expect(toTemplatePatch({ name: 'Push A' }, codec, NOW)['exercises']).toEqual([]);
+  });
+
+  it('omits unset optionals from both create and edit', () => {
+    const doc = toTemplateDoc(draft, codec, NOW);
+    const patch = toTemplatePatch(draft, codec, NOW);
+    for (const key of ['notes', 'restMiniSec', 'restClusterSec', 'seedKey']) {
+      expect(key in doc).toBe(false);
+      expect(key in patch).toBe(false);
+    }
+  });
+});
+
+describe('sessions', () => {
+  const started = new Date('2026-07-30T17:15:00Z');
+  const draft = { status: 'active' as const, date: started, exercises: [] };
+
+  it('stores the domain `date` as the `timestamp` field', () => {
+    const doc = toSessionDoc(draft, codec, NOW);
+    expect(doc.timestamp).toEqual({ ts: started.getTime() });
+    expect(doc.createdAt).toEqual(stamp);
+    expect(doc.updatedAt).toEqual(stamp);
+  });
+
+  it('carries the full draft when finishing a session', () => {
+    expect(
+      toSessionDoc(
+        {
+          ...draft,
+          status: 'completed',
+          templateId: 't1',
+          templateName: 'Push A',
+          bodyweight: 180,
+          sleepHours: 7.5,
+          durationMin: 52,
+          nextNotes: 'Bump the row',
+        },
+        codec,
+        NOW,
+      ),
+    ).toMatchObject({
+      status: 'completed',
+      templateId: 't1',
+      templateName: 'Push A',
+      bodyweight: 180,
+      sleepHours: 7.5,
+      durationMin: 52,
+      nextNotes: 'Bump the row',
+    });
+  });
+
+  it('patches only what the logger touched, always bumping updatedAt', () => {
+    expect(toSessionPatch({ bodyweight: 181 }, codec, NOW)).toEqual({
+      bodyweight: 181,
+      updatedAt: stamp,
+    });
+  });
+
+  it('distinguishes an absent field from a falsy one', () => {
+    // The live logger writes one field at a time, so a key the caller did not
+    // mention must survive the write — but 0 / '' are real values.
+    const patch = toSessionPatch({ durationMin: 0, nextNotes: '' }, codec, NOW);
+    expect(patch['durationMin']).toBe(0);
+    expect(patch['nextNotes']).toBe('');
+    expect('bodyweight' in patch).toBe(false);
+  });
+
+  it('maps a patched date onto `timestamp` too', () => {
+    const moved = new Date('2026-07-28T10:00:00Z');
+    expect(toSessionPatch({ date: moved }, codec, NOW)['timestamp']).toEqual({
+      ts: moved.getTime(),
+    });
+  });
+});
+
+describe('BATCH_CHUNK', () => {
+  it('stays under Firestore\'s 500-write cap', () => {
+    expect(BATCH_CHUNK).toBeLessThan(500);
+  });
+});

--- a/packages/core/src/firestore-writers.ts
+++ b/packages/core/src/firestore-writers.ts
@@ -1,0 +1,407 @@
+/**
+ * Domain → Firestore doc serializers, single-sourced for BOTH frontends.
+ *
+ * The write-path twin of `./firestore-mappers` (doc → domain). Every stored
+ * shape the Angular PWA and the Expo app both write is assembled here, so a
+ * new field lands once and the two adapters cannot drift apart — or drift
+ * past `firestore.rules`, which validates the shape they produce.
+ *
+ * Framework-free by design (ADR-0012): this module NEVER imports
+ * `firebase/firestore`. The read path could match `Timestamp` structurally
+ * ({@link TimestampLike}), but the write path has to *produce* SDK values —
+ * a `Timestamp` and a `deleteField()` sentinel — so each edge injects them
+ * through a {@link DocCodec}. That is the same injection `pruneUndefined`
+ * already uses for its `isOpaque` predicate.
+ *
+ * Two conventions worth knowing before adding a writer:
+ *
+ * - **Create paths return a typed doc; patch paths return a loose record.**
+ *   A patch field holds `number | <delete sentinel>`, which cannot be typed
+ *   honestly without spreading an opaque generic through every call site, so
+ *   patches are `Record<string, unknown>` on purpose.
+ * - **`now` is a parameter, never a call to the SDK's `now()`.** Keeping the
+ *   clock out of this module is what makes `createdAt` / `updatedAt`
+ *   assertable in a unit test.
+ *
+ * What deliberately stayed in the adapters: every `addDoc` / `setDoc` /
+ * `writeBatch` call, the `pruneUndefined` binding, the collection paths, and
+ * `mergeExercises` (a rewrite rule over fetched docs, not a serializer).
+ */
+import type { CustomFood, LogEntry, MealPreset, MealType, Measurement } from './types';
+import type {
+  LogStyle,
+  MuscleGroup,
+  SessionExercise,
+  SessionStatus,
+  TemplateExercise,
+} from './workout';
+
+/**
+ * The SDK values a doc needs that this module cannot construct. Each adapter
+ * binds its own Firestore SDK once:
+ * `{ timestamp: (d) => Timestamp.fromDate(d), remove: () => deleteField() }`.
+ *
+ * @typeParam TS the edge's timestamp type — `Timestamp` in both adapters,
+ *   a plain stand-in under test.
+ */
+export interface DocCodec<TS = unknown> {
+  /** Domain `Date` → the stored timestamp value. */
+  timestamp(d: Date): TS;
+  /** The "remove this field" sentinel, for patch writes only. */
+  remove(): unknown;
+}
+
+/** Firestore's per-batch write cap is 500; chunk below it with headroom for
+ *  the caller's own ops. Used by every bulk write in both adapters. */
+export const BATCH_CHUNK = 450;
+
+// ─── Daily logs ─────────────────────────────────────────────────
+
+/** `users/{uid}/dailyLogs/{id}` — validated by `isValidLog` in firestore.rules.
+ *  The legacy `liftCompleted` / `cardioCompleted` fields are absent by design:
+ *  new docs never carry them, and {@link toLogPatch} deletes them on edit. */
+export interface LogDoc<TS> {
+  calories: number;
+  timestamp: TS;
+  weight?: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+  /** Only ever written as literal `true`; a false value is an absent key. */
+  exerciseCompleted?: true;
+  mealLabel?: string;
+  mealType?: MealType;
+}
+
+/** Serialize a log for creation (`addLog`, and each row of `importLogs`).
+ *  An entry with no timestamp is stamped `now` — the undo-restore path passes
+ *  the original instant instead. */
+export function toLogDoc<TS>(
+  entry: LogEntry,
+  codec: DocCodec<TS>,
+  now: Date = new Date(),
+): LogDoc<TS> {
+  return {
+    calories: entry.calories,
+    timestamp: codec.timestamp(entry.timestamp ?? now),
+    ...(entry.weight != null ? { weight: entry.weight } : {}),
+    ...(entry.protein != null ? { protein: entry.protein } : {}),
+    ...(entry.carbs != null ? { carbs: entry.carbs } : {}),
+    ...(entry.fat != null ? { fat: entry.fat } : {}),
+    ...(entry.exerciseCompleted ? { exerciseCompleted: true as const } : {}),
+    ...(entry.mealLabel ? { mealLabel: entry.mealLabel } : {}),
+    ...(entry.mealType ? { mealType: entry.mealType } : {}),
+  };
+}
+
+/**
+ * Serialize a log edit. Unlike {@link toLogDoc} this names every optional
+ * field explicitly — a cleared macro must be *removed* from the doc, not left
+ * at its old value — and unconditionally removes the two legacy completion
+ * fields, so every edit migrates the row forward.
+ *
+ * `weight` is the exception: absent means "leave whatever is stored", because
+ * the weight is owned by the `dailyWeights` collection, not by this row.
+ */
+export function toLogPatch<TS>(entry: LogEntry, codec: DocCodec<TS>): Record<string, unknown> {
+  const patch: Record<string, unknown> = {
+    calories: entry.calories,
+    protein: entry.protein != null ? entry.protein : codec.remove(),
+    carbs: entry.carbs != null ? entry.carbs : codec.remove(),
+    fat: entry.fat != null ? entry.fat : codec.remove(),
+    exerciseCompleted: entry.exerciseCompleted ? true : codec.remove(),
+    liftCompleted: codec.remove(),
+    cardioCompleted: codec.remove(),
+    mealLabel: entry.mealLabel ? entry.mealLabel : codec.remove(),
+    mealType: entry.mealType ? entry.mealType : codec.remove(),
+  };
+  if (entry.weight != null) patch['weight'] = entry.weight;
+  if (entry.timestamp != null) patch['timestamp'] = codec.timestamp(entry.timestamp);
+  return patch;
+}
+
+// ─── Meal presets ───────────────────────────────────────────────
+
+/** `users/{uid}/presets/{id}`. No dates and no sentinels, so no codec. */
+export interface PresetDoc {
+  name: string;
+  calories: number;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+}
+
+export function toPresetDoc(preset: Omit<MealPreset, 'id'>): PresetDoc {
+  return {
+    name: preset.name,
+    calories: preset.calories,
+    ...(preset.protein != null ? { protein: preset.protein } : {}),
+    ...(preset.carbs != null ? { carbs: preset.carbs } : {}),
+    ...(preset.fat != null ? { fat: preset.fat } : {}),
+  };
+}
+
+// ─── Custom foods (My Foods library, ADR-0013) ──────────────────
+
+/** `users/{uid}/customFoods/{id}` — `isValidCustomFood` in firestore.rules.
+ *  Barcode-sourced foods are upserted at the barcode doc id (the adapter's
+ *  concern); the doc shape is identical either way. */
+export interface CustomFoodDoc<TS> {
+  name: string;
+  servingSize: number;
+  servingUnit: CustomFood['servingUnit'];
+  calories: number;
+  source: CustomFood['source'];
+  createdAt: TS;
+  brand?: string;
+  barcode?: string;
+  protein?: number;
+  carbs?: number;
+  fat?: number;
+}
+
+export function toCustomFoodDoc<TS>(
+  food: Omit<CustomFood, 'id'>,
+  codec: DocCodec<TS>,
+): CustomFoodDoc<TS> {
+  return {
+    name: food.name,
+    servingSize: food.servingSize,
+    servingUnit: food.servingUnit,
+    calories: food.calories,
+    source: food.source,
+    createdAt: codec.timestamp(food.createdAt),
+    ...(food.brand != null ? { brand: food.brand } : {}),
+    ...(food.barcode != null ? { barcode: food.barcode } : {}),
+    ...(food.protein != null ? { protein: food.protein } : {}),
+    ...(food.carbs != null ? { carbs: food.carbs } : {}),
+    ...(food.fat != null ? { fat: food.fat } : {}),
+  };
+}
+
+// ─── Body measurements ──────────────────────────────────────────
+
+/** What the user submits: the row's date is the write instant, not an input. */
+export type MeasurementInput = Omit<Measurement, 'id' | 'date'>;
+
+/** `users/{uid}/measurements/{id}` — inches. */
+export interface MeasurementDoc<TS> {
+  timestamp: TS;
+  waist?: number;
+  chest?: number;
+  bicep?: number;
+  hip?: number;
+  neck?: number;
+}
+
+export function toMeasurementDoc<TS>(
+  entry: MeasurementInput,
+  codec: DocCodec<TS>,
+  now: Date = new Date(),
+): MeasurementDoc<TS> {
+  return {
+    timestamp: codec.timestamp(now),
+    ...(entry.waist != null ? { waist: entry.waist } : {}),
+    ...(entry.chest != null ? { chest: entry.chest } : {}),
+    ...(entry.bicep != null ? { bicep: entry.bicep } : {}),
+    ...(entry.hip != null ? { hip: entry.hip } : {}),
+    ...(entry.neck != null ? { neck: entry.neck } : {}),
+  };
+}
+
+/**
+ * Serialize a measurement edit: set what was provided, remove what the user
+ * cleared. `timestamp` is deliberately absent so the row keeps its original
+ * date.
+ *
+ * Only the PWA edits measurements today; this lives here anyway, beside
+ * {@link toMeasurementDoc}, because the two share a field list and splitting
+ * them is exactly how a create path and an update path drift apart.
+ */
+export function toMeasurementPatch<TS>(
+  entry: MeasurementInput,
+  codec: DocCodec<TS>,
+): Record<string, unknown> {
+  return {
+    waist: entry.waist != null ? entry.waist : codec.remove(),
+    chest: entry.chest != null ? entry.chest : codec.remove(),
+    bicep: entry.bicep != null ? entry.bicep : codec.remove(),
+    hip: entry.hip != null ? entry.hip : codec.remove(),
+    neck: entry.neck != null ? entry.neck : codec.remove(),
+  };
+}
+
+// ─── Workout: exercise catalog ──────────────────────────────────
+// The three workout drafts are declared structurally here rather than as
+// `Omit<Exercise, …>` of the shared read-model: each frontend keeps its own
+// richer copy of these types (see ./workout's header), and the array fields
+// are optional here so a draft from either app satisfies the input.
+
+export interface ExerciseDraftInput {
+  name: string;
+  muscles?: MuscleGroup[];
+  defaultCues?: string[];
+  logStyle?: LogStyle;
+  seedKey?: string;
+}
+
+/** `users/{uid}/exercises/{id}` — `isValidExercise` in firestore.rules, which
+ *  requires both arrays to be present (hence the `?? []` defaults). */
+export interface ExerciseDoc<TS> {
+  name: string;
+  muscles: MuscleGroup[];
+  defaultCues: string[];
+  createdAt: TS;
+  logStyle?: LogStyle;
+  seedKey?: string;
+}
+
+export function toExerciseDoc<TS>(
+  draft: ExerciseDraftInput,
+  codec: DocCodec<TS>,
+  now: Date = new Date(),
+): ExerciseDoc<TS> {
+  return {
+    name: draft.name,
+    muscles: draft.muscles ?? [],
+    defaultCues: draft.defaultCues ?? [],
+    createdAt: codec.timestamp(now),
+    ...(draft.logStyle !== undefined ? { logStyle: draft.logStyle } : {}),
+    ...(draft.seedKey !== undefined ? { seedKey: draft.seedKey } : {}),
+  };
+}
+
+// ─── Workout: templates ─────────────────────────────────────────
+
+export interface TemplateDraftInput {
+  name: string;
+  notes?: string;
+  restMiniSec?: number;
+  restClusterSec?: number;
+  exercises?: TemplateExercise[];
+  seedKey?: string;
+}
+
+/** `users/{uid}/workoutTemplates/{id}` — `isValidWorkoutTemplate`. */
+export interface TemplateDoc<TS> {
+  name: string;
+  exercises: TemplateExercise[];
+  createdAt: TS;
+  updatedAt: TS;
+  notes?: string;
+  restMiniSec?: number;
+  restClusterSec?: number;
+  seedKey?: string;
+}
+
+function templateFields(draft: TemplateDraftInput) {
+  return {
+    name: draft.name,
+    exercises: draft.exercises ?? [],
+    ...(draft.notes !== undefined ? { notes: draft.notes } : {}),
+    ...(draft.restMiniSec !== undefined ? { restMiniSec: draft.restMiniSec } : {}),
+    ...(draft.restClusterSec !== undefined ? { restClusterSec: draft.restClusterSec } : {}),
+    ...(draft.seedKey !== undefined ? { seedKey: draft.seedKey } : {}),
+  };
+}
+
+export function toTemplateDoc<TS>(
+  draft: TemplateDraftInput,
+  codec: DocCodec<TS>,
+  now: Date = new Date(),
+): TemplateDoc<TS> {
+  const stamp = codec.timestamp(now);
+  return { ...templateFields(draft), createdAt: stamp, updatedAt: stamp };
+}
+
+/**
+ * Serialize a template edit. Same fields minus `createdAt`, which the write
+ * must leave alone — the adapters apply this with `{ merge: true }`, and a
+ * merge that carried `createdAt` would reset the row's age.
+ *
+ * Note this is a full overwrite of the mutable fields, not a sparse patch: a
+ * merged `exercises` array would union with the stored one rather than
+ * replace it, so every edit rewrites the whole list.
+ */
+export function toTemplatePatch<TS>(
+  draft: TemplateDraftInput,
+  codec: DocCodec<TS>,
+  now: Date = new Date(),
+): Record<string, unknown> {
+  return { ...templateFields(draft), updatedAt: codec.timestamp(now) };
+}
+
+// ─── Workout: sessions ──────────────────────────────────────────
+
+export interface SessionDraftInput {
+  status: SessionStatus;
+  date: Date;
+  templateId?: string;
+  templateName?: string;
+  bodyweight?: number;
+  sleepHours?: number;
+  durationMin?: number;
+  exercises?: SessionExercise[];
+  nextNotes?: string;
+}
+
+/** `users/{uid}/workoutSessions/{id}` — `isValidWorkoutSession`. The domain
+ *  calls it `date`; the stored field is `timestamp`, matching every other
+ *  time-ordered collection. */
+export interface SessionDoc<TS> {
+  status: SessionStatus;
+  timestamp: TS;
+  exercises: SessionExercise[];
+  createdAt: TS;
+  updatedAt: TS;
+  templateId?: string;
+  templateName?: string;
+  bodyweight?: number;
+  sleepHours?: number;
+  durationMin?: number;
+  nextNotes?: string;
+}
+
+export function toSessionDoc<TS>(
+  draft: SessionDraftInput,
+  codec: DocCodec<TS>,
+  now: Date = new Date(),
+): SessionDoc<TS> {
+  const stamp = codec.timestamp(now);
+  return {
+    status: draft.status,
+    timestamp: codec.timestamp(draft.date),
+    exercises: draft.exercises ?? [],
+    createdAt: stamp,
+    updatedAt: stamp,
+    ...(draft.templateId !== undefined ? { templateId: draft.templateId } : {}),
+    ...(draft.templateName !== undefined ? { templateName: draft.templateName } : {}),
+    ...(draft.bodyweight !== undefined ? { bodyweight: draft.bodyweight } : {}),
+    ...(draft.sleepHours !== undefined ? { sleepHours: draft.sleepHours } : {}),
+    ...(draft.durationMin !== undefined ? { durationMin: draft.durationMin } : {}),
+    ...(draft.nextNotes !== undefined ? { nextNotes: draft.nextNotes } : {}),
+  };
+}
+
+/**
+ * Serialize a live-session update. Genuinely sparse — the logger writes one
+ * field at a time as the user works — so a key absent from `patch` is left
+ * untouched rather than removed. `updatedAt` always advances.
+ */
+export function toSessionPatch<TS>(
+  patch: Partial<SessionDraftInput>,
+  codec: DocCodec<TS>,
+  now: Date = new Date(),
+): Record<string, unknown> {
+  const data: Record<string, unknown> = { updatedAt: codec.timestamp(now) };
+  if (patch.status !== undefined) data['status'] = patch.status;
+  if (patch.templateId !== undefined) data['templateId'] = patch.templateId;
+  if (patch.templateName !== undefined) data['templateName'] = patch.templateName;
+  if (patch.date !== undefined) data['timestamp'] = codec.timestamp(patch.date);
+  if (patch.bodyweight !== undefined) data['bodyweight'] = patch.bodyweight;
+  if (patch.sleepHours !== undefined) data['sleepHours'] = patch.sleepHours;
+  if (patch.durationMin !== undefined) data['durationMin'] = patch.durationMin;
+  if (patch.exercises !== undefined) data['exercises'] = patch.exercises;
+  if (patch.nextNotes !== undefined) data['nextNotes'] = patch.nextNotes;
+  return data;
+}

--- a/packages/core/src/health-mapping.test.ts
+++ b/packages/core/src/health-mapping.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
-  DAILY_FOLD,
+  DAILY_FOLD, SLEEP_MAX_HOURS, WATER_MAX_FLOZ,
+  clampSleepHours, clampWaterFlOz,
   fractionToPercent, flOzToLiters, isStorableHealthValue, kgToLb, lbToKg, litersToFlOz,
   percentToFraction, reduceImportedSamples, valuesToApply,
   type HealthKind, type HealthSample,
@@ -204,5 +205,22 @@ describe('activity import (steps / active energy)', () => {
       sample({ kind: 'steps', dateKey: '2026-07-01', value: 3000, endMs: 200 }),
     ]);
     expect(out['2026-07-01']).toBe(3000);
+  });
+});
+
+describe('write-path clamps', () => {
+  // Applied by both Firestore adapters, the in-memory adapter and the store's
+  // pre-write clamp — these are the bound, not a copy of it.
+  it('clamps water to [0, WATER_MAX_FLOZ] and rounds to whole fl oz', () => {
+    expect(clampWaterFlOz(-5)).toBe(0);
+    expect(clampWaterFlOz(64.4)).toBe(64);
+    expect(clampWaterFlOz(WATER_MAX_FLOZ + 1)).toBe(WATER_MAX_FLOZ);
+  });
+
+  it('clamps sleep to [0, 24] and snaps to the half hour', () => {
+    expect(clampSleepHours(-1)).toBe(0);
+    expect(clampSleepHours(7.3)).toBe(7.5);
+    expect(clampSleepHours(7.1)).toBe(7);
+    expect(clampSleepHours(SLEEP_MAX_HOURS + 3)).toBe(SLEEP_MAX_HOURS);
   });
 });

--- a/packages/core/src/health-mapping.ts
+++ b/packages/core/src/health-mapping.ts
@@ -62,8 +62,29 @@ export const flOzToLiters = (flOz: number): number => flOz / FL_OZ_PER_LITER;
 export const fractionToPercent = (f: number): number => f * 100;
 export const percentToFraction = (p: number): number => p / 100;
 
-/** Water clamp — mirrors the ledger's `dailyWater` bound (fl oz). */
+/** Upper bound on a day's water, in fl oz (~5 gal). The canonical bound: the
+ *  ledger's `dailyWater` writes clamp to it via {@link clampWaterFlOz}, and
+ *  firestore.rules mirrors the same number. */
 export const WATER_MAX_FLOZ = 676;
+
+/** Upper bound on a day's sleep, in hours. */
+export const SLEEP_MAX_HOURS = 24;
+
+/**
+ * Clamp a day's water to the storable range and round to whole fl oz. Applied
+ * on every write path — both Firestore adapters, the in-memory adapter, and
+ * the store's own pre-write clamp — so a fat-fingered entry can't reach a
+ * chart, and no two of those sites can disagree about what "too much" is.
+ */
+export function clampWaterFlOz(flOz: number): number {
+  return Math.max(0, Math.min(WATER_MAX_FLOZ, Math.round(flOz)));
+}
+
+/** Clamp a day's sleep to `[0, 24]` hours, snapped to the half hour the UI
+ *  offers. Same four write paths as {@link clampWaterFlOz}. */
+export function clampSleepHours(hours: number): number {
+  return Math.max(0, Math.min(SLEEP_MAX_HOURS, Math.round(hours * 2) / 2));
+}
 
 /** Activity clamps. Both are generous by design — the point is to reject
  *  corrupt or duplicated data, not to referee an ultramarathon. The world
@@ -83,7 +104,7 @@ export function isStorableHealthValue(kind: HealthKind, value: number): boolean 
     case 'weight':
       return isStorableWeight(value);
     case 'sleep':
-      return value > 0 && value <= 24;
+      return value > 0 && value <= SLEEP_MAX_HOURS;
     case 'water':
       return value >= 0 && value <= WATER_MAX_FLOZ;
     case 'bodyFat':

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -121,3 +121,7 @@ export * from './prune-undefined';
 // prune-undefined. Structural Timestamp → Date (no firebase import); both
 // frontends' adapters map here. Workout mappers stay per-frontend (see file).
 export * from './firestore-mappers';
+// Shared Firestore WRITE-path serializers (domain → doc), the twin of the
+// mappers above. Also pure, but a write must PRODUCE SDK values, so each edge
+// injects Timestamp/deleteField through a DocCodec. Adapters keep their I/O.
+export * from './firestore-writers';

--- a/src/app/ledger/infrastructure/firestore-ledger.core.ts
+++ b/src/app/ledger/infrastructure/firestore-ledger.core.ts
@@ -46,15 +46,38 @@ import type {
 import { normalizeClusterGroups } from '../../utils/cluster-groups';
 import { pruneUndefined as pruneUndefinedCore } from '@macrolog/core/prune-undefined';
 import {
+  BATCH_CHUNK,
+  clampSleepHours,
+  clampWaterFlOz,
   oldestFirst,
   toCustomFood,
+  toCustomFoodDoc,
   toDailyLog,
+  toExerciseDoc,
+  toLogDoc,
+  toLogPatch,
   toMeasurement,
+  toMeasurementDoc,
+  toMeasurementPatch,
+  toPresetDoc,
+  toSessionDoc,
+  toSessionPatch,
+  toTemplateDoc,
+  toTemplatePatch,
   toWeeklyReport,
   toWorkoutExercise,
   toWorkoutTemplate,
   toWorkoutSession,
+  type DocCodec,
 } from '@macrolog/core';
+
+/** The two SDK values the shared writers can't construct themselves, bound to
+ *  this edge's Firestore SDK once (see `@macrolog/core/firestore-writers`).
+ *  The Expo adapter binds the identical pair against its own SDK copy. */
+const CODEC: DocCodec<Timestamp> = {
+  timestamp: (d) => Timestamp.fromDate(d),
+  remove: () => deleteField(),
+};
 
 /**
  * Framework-free Firestore I/O core for the ledger adapter (issue #6
@@ -124,18 +147,7 @@ export class FirestoreLedgerCore {
   // ─── Daily logs ────────────────────────────────────────────────
 
   async addLog(entry: LogEntry): Promise<string> {
-    const data: Record<string, unknown> = {
-      calories: entry.calories,
-      timestamp: Timestamp.fromDate(entry.timestamp ?? new Date()),
-    };
-    if (entry.weight != null) data['weight'] = entry.weight;
-    if (entry.protein != null) data['protein'] = entry.protein;
-    if (entry.carbs != null) data['carbs'] = entry.carbs;
-    if (entry.fat != null) data['fat'] = entry.fat;
-    if (entry.exerciseCompleted) data['exerciseCompleted'] = true;
-    if (entry.mealLabel) data['mealLabel'] = entry.mealLabel;
-    if (entry.mealType) data['mealType'] = entry.mealType;
-    const ref = await addDoc(this.userCollection('dailyLogs'), data);
+    const ref = await addDoc(this.userCollection('dailyLogs'), toLogDoc(entry, CODEC));
     return ref.id;
   }
 
@@ -149,21 +161,7 @@ export class FirestoreLedgerCore {
   }
 
   async updateLog(logId: string, entry: LogEntry): Promise<void> {
-    const data: Record<string, unknown> = {
-      calories: entry.calories,
-      protein: entry.protein != null ? entry.protein : deleteField(),
-      carbs: entry.carbs != null ? entry.carbs : deleteField(),
-      fat: entry.fat != null ? entry.fat : deleteField(),
-      exerciseCompleted: entry.exerciseCompleted ? true : deleteField(),
-      // Migrate away from legacy fields on every edit.
-      liftCompleted: deleteField(),
-      cardioCompleted: deleteField(),
-      mealLabel: entry.mealLabel ? entry.mealLabel : deleteField(),
-      mealType: entry.mealType ? entry.mealType : deleteField(),
-    };
-    if (entry.weight != null) data['weight'] = entry.weight;
-    if (entry.timestamp != null) data['timestamp'] = Timestamp.fromDate(entry.timestamp);
-    await updateDoc(this.userDocIn('dailyLogs', logId), data);
+    await updateDoc(this.userDocIn('dailyLogs', logId), toLogPatch(entry, CODEC));
   }
 
   async deleteLog(logId: string): Promise<void> {
@@ -171,32 +169,20 @@ export class FirestoreLedgerCore {
   }
 
   /**
-   * Bulk-create log rows (switcher import). Batched in ≤450-write chunks
-   * to stay under Firestore's 500-op limit, same pattern as
-   * mergeExercises. Field semantics mirror addLog exactly. Returns the
-   * number of rows written. NOT atomic across chunks — a mid-import
-   * failure leaves earlier chunks committed (caller surfaces the count).
+   * Bulk-create log rows (switcher import). Batched in ≤`BATCH_CHUNK`-write
+   * chunks to stay under Firestore's 500-op limit, same pattern as
+   * mergeExercises. Rows are serialized by the same `toLogDoc` addLog uses, so
+   * an imported row and a typed one cannot differ. Returns the number of rows
+   * written. NOT atomic across chunks — a mid-import failure leaves earlier
+   * chunks committed (caller surfaces the count).
    */
   async importLogs(entries: readonly LogEntry[]): Promise<number> {
     const coll = this.userCollection('dailyLogs');
     let written = 0;
-    for (let i = 0; i < entries.length; i += 450) {
+    for (let i = 0; i < entries.length; i += BATCH_CHUNK) {
       const batch = writeBatch(this.firestore);
-      const chunk = entries.slice(i, i + 450);
-      for (const entry of chunk) {
-        const data: Record<string, unknown> = {
-          calories: entry.calories,
-          timestamp: Timestamp.fromDate(entry.timestamp ?? new Date()),
-        };
-        if (entry.weight != null) data['weight'] = entry.weight;
-        if (entry.protein != null) data['protein'] = entry.protein;
-        if (entry.carbs != null) data['carbs'] = entry.carbs;
-        if (entry.fat != null) data['fat'] = entry.fat;
-        if (entry.exerciseCompleted) data['exerciseCompleted'] = true;
-        if (entry.mealLabel) data['mealLabel'] = entry.mealLabel;
-        if (entry.mealType) data['mealType'] = entry.mealType;
-        batch.set(doc(coll), data);
-      }
+      const chunk = entries.slice(i, i + BATCH_CHUNK);
+      for (const entry of chunk) batch.set(doc(coll), toLogDoc(entry, CODEC));
       await batch.commit();
       written += chunk.length;
     }
@@ -246,9 +232,7 @@ export class FirestoreLedgerCore {
   }
 
   async setDailyWater(dateKey: string, flOz: number): Promise<void> {
-    await setDoc(this.userDocIn('dailyWater', dateKey), {
-      flOz: Math.max(0, Math.min(676, Math.round(flOz))),
-    });
+    await setDoc(this.userDocIn('dailyWater', dateKey), { flOz: clampWaterFlOz(flOz) });
   }
 
   // ─── Daily sleep ──────────────────────────────────────────────
@@ -268,9 +252,7 @@ export class FirestoreLedgerCore {
   }
 
   async setDailySleep(dateKey: string, hours: number): Promise<void> {
-    await setDoc(this.userDocIn('dailySleep', dateKey), {
-      hours: Math.max(0, Math.min(24, Math.round(hours * 2) / 2)),
-    });
+    await setDoc(this.userDocIn('dailySleep', dateKey), { hours: clampSleepHours(hours) });
   }
 
   // ─── Meal presets ─────────────────────────────────────────────
@@ -281,14 +263,7 @@ export class FirestoreLedgerCore {
   }
 
   async addPreset(preset: Omit<MealPreset, 'id'>): Promise<string> {
-    const data: Record<string, unknown> = {
-      name: preset.name,
-      calories: preset.calories,
-    };
-    if (preset.protein != null) data['protein'] = preset.protein;
-    if (preset.carbs != null) data['carbs'] = preset.carbs;
-    if (preset.fat != null) data['fat'] = preset.fat;
-    const ref = await addDoc(this.userCollection('presets'), data);
+    const ref = await addDoc(this.userCollection('presets'), toPresetDoc(preset));
     return ref.id;
   }
 
@@ -307,19 +282,7 @@ export class FirestoreLedgerCore {
    *  write is a deterministic upsert at that id (de-dup + re-scan match);
    *  omit it for an auto-id. `createdAt` maps Date → Timestamp at the seam. */
   async addCustomFood(food: Omit<CustomFood, 'id'>, id?: string | null): Promise<string> {
-    const data: Record<string, unknown> = {
-      name: food.name,
-      servingSize: food.servingSize,
-      servingUnit: food.servingUnit,
-      calories: food.calories,
-      source: food.source,
-      createdAt: Timestamp.fromDate(food.createdAt),
-    };
-    if (food.brand != null) data['brand'] = food.brand;
-    if (food.barcode != null) data['barcode'] = food.barcode;
-    if (food.protein != null) data['protein'] = food.protein;
-    if (food.carbs != null) data['carbs'] = food.carbs;
-    if (food.fat != null) data['fat'] = food.fat;
+    const data = toCustomFoodDoc(food, CODEC);
     if (id) {
       await setDoc(this.userDocIn('customFoods', id), data);
       return id;
@@ -353,26 +316,13 @@ export class FirestoreLedgerCore {
   }
 
   async addMeasurement(entry: Omit<Measurement, 'id' | 'date'>): Promise<string> {
-    const data: Record<string, unknown> = { timestamp: Timestamp.now() };
-    if (entry.waist != null) data['waist'] = entry.waist;
-    if (entry.chest != null) data['chest'] = entry.chest;
-    if (entry.bicep != null) data['bicep'] = entry.bicep;
-    if (entry.hip != null) data['hip'] = entry.hip;
-    if (entry.neck != null) data['neck'] = entry.neck;
-    const ref = await addDoc(this.userCollection('measurements'), data);
+    const ref = await addDoc(this.userCollection('measurements'), toMeasurementDoc(entry, CODEC));
     return ref.id;
   }
 
   async updateMeasurement(id: string, entry: Omit<Measurement, 'id' | 'date'>): Promise<void> {
-    // Leave `timestamp` untouched so the row keeps its original date; set
-    // provided fields and remove any the caller cleared.
-    await updateDoc(this.userDocIn('measurements', id), {
-      waist: entry.waist != null ? entry.waist : deleteField(),
-      chest: entry.chest != null ? entry.chest : deleteField(),
-      bicep: entry.bicep != null ? entry.bicep : deleteField(),
-      hip: entry.hip != null ? entry.hip : deleteField(),
-      neck: entry.neck != null ? entry.neck : deleteField(),
-    });
+    // The patch leaves `timestamp` alone so the row keeps its original date.
+    await updateDoc(this.userDocIn('measurements', id), toMeasurementPatch(entry, CODEC));
   }
 
   async deleteMeasurement(id: string): Promise<void> {
@@ -387,15 +337,10 @@ export class FirestoreLedgerCore {
   }
 
   async addExercise(exercise: ExerciseDraft): Promise<string> {
-    const data: ExerciseDoc = {
-      name: exercise.name,
-      muscles: exercise.muscles ?? [],
-      defaultCues: exercise.defaultCues ?? [],
-      logStyle: exercise.logStyle,
-      seedKey: exercise.seedKey,
-      createdAt: Timestamp.now(),
-    };
-    const ref = await addDoc(this.userCollection('exercises'), pruneUndefined(data));
+    const ref = await addDoc(
+      this.userCollection('exercises'),
+      pruneUndefined(toExerciseDoc(exercise, CODEC)),
+    );
     return ref.id;
   }
 
@@ -411,7 +356,8 @@ export class FirestoreLedgerCore {
    * Merge exercise `fromId` into `toId`: rewrite every session and template
    * that references the victim so it points at the survivor (and adopts the
    * survivor's display name), then delete the victim catalog doc. Writes are
-   * chunked into ≤450-op batches to stay under Firestore's 500-write limit.
+   * chunked into ≤`BATCH_CHUNK`-op batches to stay under Firestore's 500-write
+   * limit.
    */
   async mergeExercises(fromId: string, toId: string): Promise<void> {
     if (fromId === toId) return;
@@ -442,9 +388,9 @@ export class FirestoreLedgerCore {
       if (next) ops.push({ ref: d.ref, exercises: next });
     });
 
-    for (let i = 0; i < ops.length; i += 450) {
+    for (let i = 0; i < ops.length; i += BATCH_CHUNK) {
       const batch = writeBatch(this.firestore);
-      for (const op of ops.slice(i, i + 450)) {
+      for (const op of ops.slice(i, i + BATCH_CHUNK)) {
         batch.update(op.ref, pruneUndefined({ exercises: op.exercises, updatedAt: Timestamp.now() }));
       }
       await batch.commit();
@@ -461,33 +407,17 @@ export class FirestoreLedgerCore {
   }
 
   async addTemplate(template: TemplateDraft): Promise<string> {
-    const now = Timestamp.now();
-    const data = pruneUndefined({
-      name: template.name,
-      notes: template.notes,
-      restMiniSec: template.restMiniSec,
-      restClusterSec: template.restClusterSec,
-      exercises: template.exercises ?? [],
-      seedKey: template.seedKey,
-      createdAt: now,
-      updatedAt: now,
-    });
-    const ref = await addDoc(this.userCollection('workoutTemplates'), data);
+    const ref = await addDoc(
+      this.userCollection('workoutTemplates'),
+      pruneUndefined(toTemplateDoc(template, CODEC)),
+    );
     return ref.id;
   }
 
   async updateTemplate(id: string, template: TemplateDraft): Promise<void> {
     // Full overwrite of mutable fields + bump updatedAt; createdAt left
     // untouched by merge.
-    const data = pruneUndefined({
-      name: template.name,
-      notes: template.notes,
-      restMiniSec: template.restMiniSec,
-      restClusterSec: template.restClusterSec,
-      exercises: template.exercises ?? [],
-      seedKey: template.seedKey,
-      updatedAt: Timestamp.now(),
-    });
+    const data = pruneUndefined(toTemplatePatch(template, CODEC));
     await setDoc(this.userDocIn('workoutTemplates', id), data, { merge: true });
   }
 
@@ -530,36 +460,16 @@ export class FirestoreLedgerCore {
   }
 
   async startSession(session: SessionDraft): Promise<string> {
-    const now = Timestamp.now();
-    const data = pruneUndefined({
-      status: session.status,
-      templateId: session.templateId,
-      templateName: session.templateName,
-      timestamp: Timestamp.fromDate(session.date),
-      bodyweight: session.bodyweight,
-      sleepHours: session.sleepHours,
-      durationMin: session.durationMin,
-      exercises: session.exercises ?? [],
-      nextNotes: session.nextNotes,
-      createdAt: now,
-      updatedAt: now,
-    });
-    const ref = await addDoc(this.userCollection('workoutSessions'), data);
+    const ref = await addDoc(
+      this.userCollection('workoutSessions'),
+      pruneUndefined(toSessionDoc(session, CODEC)),
+    );
     return ref.id;
   }
 
   async updateSession(id: string, patch: Partial<SessionDraft>): Promise<void> {
-    const data: Record<string, unknown> = { updatedAt: Timestamp.now() };
-    if (patch.status !== undefined) data['status'] = patch.status;
-    if (patch.templateId !== undefined) data['templateId'] = patch.templateId;
-    if (patch.templateName !== undefined) data['templateName'] = patch.templateName;
-    if (patch.date !== undefined) data['timestamp'] = Timestamp.fromDate(patch.date);
-    if (patch.bodyweight !== undefined) data['bodyweight'] = patch.bodyweight;
-    if (patch.sleepHours !== undefined) data['sleepHours'] = patch.sleepHours;
-    if (patch.durationMin !== undefined) data['durationMin'] = patch.durationMin;
-    if (patch.exercises !== undefined) data['exercises'] = patch.exercises;
-    if (patch.nextNotes !== undefined) data['nextNotes'] = patch.nextNotes;
-    await setDoc(this.userDocIn('workoutSessions', id), pruneUndefined(data), { merge: true });
+    const data = pruneUndefined(toSessionPatch(patch, CODEC));
+    await setDoc(this.userDocIn('workoutSessions', id), data, { merge: true });
   }
 
   async deleteSession(id: string): Promise<void> {

--- a/src/app/ledger/infrastructure/in-memory-ledger.adapter.ts
+++ b/src/app/ledger/infrastructure/in-memory-ledger.adapter.ts
@@ -1,4 +1,5 @@
 import { Injectable, computed, signal } from '@angular/core';
+import { clampSleepHours, clampWaterFlOz } from '@macrolog/core';
 import type { LedgerPort } from '../ports/ledger.port';
 import type {
   Exercise,
@@ -274,7 +275,9 @@ export class InMemoryLedgerAdapter implements LedgerPort {
   }
 
   async setDailyWater(dateKey: string, flOz: number): Promise<void> {
-    this.water[dateKey] = Math.max(0, Math.min(676, Math.round(flOz)));
+    // Same shared clamp the Firestore adapter applies — a test double that
+    // clamps differently from the thing it doubles is worse than none.
+    this.water[dateKey] = clampWaterFlOz(flOz);
   }
 
   async getDailySleep(): Promise<Record<string, number>> {
@@ -282,7 +285,7 @@ export class InMemoryLedgerAdapter implements LedgerPort {
   }
 
   async setDailySleep(dateKey: string, hours: number): Promise<void> {
-    this.sleep[dateKey] = Math.max(0, Math.min(24, Math.round(hours * 2) / 2));
+    this.sleep[dateKey] = clampSleepHours(hours);
   }
 
   async getPresets(): Promise<MealPreset[]> {

--- a/src/app/services/body-metric-store.service.ts
+++ b/src/app/services/body-metric-store.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Signal, computed, inject, signal } from '@angular/core';
+import { clampSleepHours, clampWaterFlOz } from '@macrolog/core';
 import { LEDGER_PORT } from '../ledger/ports/ledger.port';
 import { Measurement } from './firebase.service';
 import { isStorableWeight, WEIGHT_ABS_MIN_LB, WEIGHT_ABS_MAX_LB } from '../utils/weight-validation';
@@ -91,7 +92,9 @@ export class BodyMetricStore {
 
   /** Overwrite the water intake total for a specific day (US fluid ounces). */
   async setDailyWater(dateKey: string, flOz: number): Promise<void> {
-    const clamped = Math.max(0, Math.min(676, Math.round(flOz)));
+    // Clamped here as well as in the adapter, so the optimistic signal update
+    // below shows the value that actually got stored.
+    const clamped = clampWaterFlOz(flOz);
     await this.fb.setDailyWater(dateKey, clamped);
     this._dailyWater.update((prev) => ({ ...prev, [dateKey]: clamped }));
   }
@@ -109,7 +112,7 @@ export class BodyMetricStore {
    *  half-hour steps. Canonical record — the workout-finish mirror writes
    *  here too (see FitnessStore.finishWorkout). */
   async setDailySleep(dateKey: string, hours: number): Promise<void> {
-    const clamped = Math.max(0, Math.min(24, Math.round(hours * 2) / 2));
+    const clamped = clampSleepHours(hours);
     await this.fb.setDailySleep(dateKey, clamped);
     this._dailySleep.update((prev) => ({ ...prev, [dateKey]: clamped }));
   }


### PR DESCRIPTION
## What

`firestore-mappers` already single-sourced the **read** path (doc → domain). The **write** path was still duplicated: `logData` in the Expo adapter and the inline object literals in `FirestoreLedgerCore` assembled the same stored shapes twice. A new field had to land in two places to satisfy `firestore.rules` — and silently diverged if it didn't.

This adds `packages/core/src/firestore-writers.ts`, the write-path twin: every shape both apps write, in one place.

`toLogDoc`/`toLogPatch` · `toPresetDoc` · `toCustomFoodDoc` · `toMeasurementDoc`/`Patch` · `toExerciseDoc` · `toTemplateDoc`/`Patch` · `toSessionDoc`/`Patch` · `BATCH_CHUNK`

## How it stays framework-free

A read can recognize a `Timestamp` structurally. A write has to **produce** SDK values, so each adapter injects a `DocCodec`:

```ts
const CODEC: DocCodec<Timestamp> = {
  timestamp: (d) => Timestamp.fromDate(d),
  remove: () => deleteField(),
};
```

Both adapters bind an identical pair against their own SDK copy — that's what makes the emitted docs byte-identical, and it keeps `packages/core` free of `firebase/firestore` (ADR-0012, and the single-SDK-copy rule). It's the same injection `pruneUndefined` already uses for `isOpaque`.

Two conventions, documented in the module header:

- **Create paths return a typed doc; patch paths return a loose record.** A patch field holds `number | <delete sentinel>`, which can't be typed honestly without spreading an opaque generic through every call site.
- **`now` is a parameter, never an SDK call** — that's what makes `createdAt`/`updatedAt` assertable in a unit test.

## Clamps

Promotes the water/sleep bounds to `clampWaterFlOz` / `clampSleepHours` in `health-mapping.ts`. They were open-coded at four sites — both Firestore adapters, the in-memory double, and `BodyMetricStore` — and `firestore.rules` mirrors the same number. A test double that clamps differently from the thing it doubles is worse than no double.

## Not in scope

Adapters keep all I/O, the collection paths, their `pruneUndefined` binding, and `mergeExercises` (a rewrite rule over fetched docs, not a serializer).

## Verification

Behavior is unchanged by design, so the emulator suites carry the weight — they assert the actual stored shapes against real rules.

| Suite | Result |
|---|---|
| `npm --prefix packages/core test` | 528 passed (39 files) |
| `npm test` (web unit) | 191 passed, 31 skipped |
| `npm run test:ledger` (Firestore emulator) | **29 passed** |
| `npm run test:rules` (firestore.rules) | **144 passed** (7 files) |
| Angular PWA `npm run build` | ✅ 105 SEO pages (en 52 / es 53), 114-URL sitemap |
| `packages/core` typecheck | ✅ |
| `functions` build | ✅ |
| Expo `tsc --noEmit` | ✅ |

No rules change, so nothing to deploy ahead of clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
