### PR TITLE
chore(eas): stop uploading 171 MB of git history on every build

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,76 @@
+# What gets uploaded to EAS as the build archive.
+#
+# READ THIS BEFORE EDITING. Once this file exists, EAS stops reading
+# .gitignore ENTIRELY — only `.git` and `node_modules` are ignored by default,
+# and every other pattern has to be repeated here. That is why this file
+# duplicates so much of .gitignore: dropping a line here does not fall back to
+# the git rule, it starts uploading the directory.
+#
+# Why it exists: the archive was 172 MB, and 171 MB of that was `.git`. EAS
+# keeps the git directory in the archive unless it is explicitly ignored here.
+# This repo's history is heavy because node_modules was committed at some
+# point — the pack still carries ~138 MB of rolldown/sharp/esbuild binaries
+# that no longer exist in any checkout. Excluding `.git` sidesteps all of it
+# without rewriting public history.
+#
+# Only apps/mobile + packages/* + the root manifests are needed to build.
+
+# The prize: ~171 MB of history the build never reads.
+.git
+
+# Node (also EAS-default, repeated so this file stands alone).
+node_modules
+
+# Generated native projects — `expo prebuild` regenerates them on the worker,
+# and android/ alone is ~291 MB locally.
+apps/mobile/android
+apps/mobile/ios
+apps/mobile/dist
+apps/mobile/.expo
+.expo
+
+# The Angular PWA's build output and caches. Not part of a mobile build.
+/dist
+/.angular
+/out-tsc
+/coverage
+/.firebase
+
+# Cloud Functions build output (source stays — it is small and harmless).
+/functions/lib
+
+# Store + marketing assets: composited screenshots, raw captures, fonts, and
+# the web app's screenshot set. ~19 MB, none of it reachable from the app.
+store-assets/
+public/screenshots/
+
+# Local-only state and scratch.
+_attic/
+_outer-junk-git-backup/
+.playwright-mcp/
+.emulator-data/
+ux-audit/
+*-debug.log
+
+# Secrets and machine-local notes — belt and braces; these are gitignored too,
+# but this file is what EAS actually honors.
+.env
+.env.local
+.env.production
+.env*.local
+.sentryclirc
+CLAUDE.local.md
+apps/mobile/credentials/
+apps/mobile/credentials.json
+*.keystore
+*.p8
+*.p12
+*.mobileprovision
+
+# Editor/system/agent noise.
+.claude/
+.github/
+.idea/
+.vscode/
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Fixes the `Your project archive is 172 MB` warning.

## Cause

Not the source tree — tracked files total **21.6 MB**. The archive was **`.git`**, which is **171.2 MB**. EAS keeps the git directory in the archive *unless it is explicitly ignored*.

The history is heavy because `node_modules` was committed at some point. The pack still carries binaries that exist in no checkout:

| Size | Blob |
|---|---|
| 20.0 MB | `functions/node_modules/@rolldown/binding-win32-arm64-msvc/…node` |
| 18.4 MB | `node_modules/@rolldown/binding-win32-arm64-msvc/…node` |
| 14.7 MB | `node_modules/@img/sharp-win32-arm64/lib/libvips-42.dll` |
| 9.7 MB | `node_modules/@esbuild/win32-arm64/esbuild.exe` |

Excluding `.git` sidesteps all of it **without rewriting public history**.

## The trap this file has to survive

Once `.easignore` exists, **EAS stops reading `.gitignore` entirely** — only `.git` and `node_modules` stay ignored by default. A one-line `.easignore` containing just `.git` would have *started* uploading `apps/mobile/android` (~291 MB) and every other gitignored directory, making the problem worse while looking like a fix.

So this is a deliberate **superset** of the root + mobile ignore rules, and the file header says so, because the failure mode is silent and points the wrong way.

Generated native projects are excluded on purpose — `expo prebuild` regenerates them on the worker. Local signing material (`credentials/`, `*.keystore`) stays excluded exactly as `.gitignore` already had it, which is the status quo Android builds already pass under.

## Verification

Measured with the same `ignore` package eas-cli uses, applying its `defaultIgnore` plus this file:

**172 MB → 7.5 MB**

Largest survivors: `public` 1.7 · `apps` 1.5 · `src` 1.3 · `package-lock.json` 0.7 · `functions` 0.5 · `packages` 0.4 MB.

Required build inputs asserted still present: root manifests, `apps/mobile` source + `plugins` + `targets/widget`, `app.json`, `eas.json`, `index.js`, `metro.config.js`, and `packages/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)