### PR TITLE
fix(mobile): widget storage module never linked + localized empty state

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -10,6 +10,7 @@
     "backgroundColor": "#faf9f6",
     "ios": {
       "bundleIdentifier": "fit.ignia.app",
+      "appleTeamId": "AE6TTXW92K",
       "supportsTablet": false,
       "usesAppleSignIn": true,
       "entitlements": {

--- a/apps/mobile/src/lib/widget.ts
+++ b/apps/mobile/src/lib/widget.ts
@@ -68,6 +68,44 @@ async function persist(snapshot: WidgetSnapshot): Promise<void> {
     // only refresh on its own (slow, OS-chosen) cadence and a just-logged meal
     // wouldn't show up until much later.
     ExtensionStorage.reloadWidget(WIDGET_NAME);
+    if (__DEV__) {
+      // `UserDefaults(suiteName:)` returns nil when the process is not entitled
+      // to the App Group, and the write then no-ops WITHOUT throwing. Reading
+      // straight back is the only way to tell "wrote it" from "pretended to".
+      // `@bacons/apple-targets` substitutes SILENT STUBS when its native module
+      // is missing — `setString`/`reloadWidget` become no-ops and `get` returns
+      // undefined — so an absent module is indistinguishable from a successful
+      // write unless the module itself is probed. Check that FIRST; a read-back
+      // miss means nothing if nothing was ever really written.
+      const native = (globalThis as unknown as { expo?: { modules?: Record<string, unknown> } })
+        .expo?.modules?.['ExtensionStorage'];
+      const echo = storage.get(WIDGET_SNAPSHOT_KEY);
+      if (!native) {
+        const all = Object.keys(
+          (globalThis as unknown as { expo?: { modules?: Record<string, unknown> } }).expo
+            ?.modules ?? {},
+        ).sort();
+        console.warn(
+          '[widget] ExtensionStorage NATIVE MODULE MISSING — set()/reloadWidget() are ' +
+            'no-ops in this binary. Nothing was written; the widget cannot possibly update.',
+        );
+        // If the registry is well populated and only this one is absent, the
+        // fault is package-specific (autolinking skipped it). If it is tiny or
+        // empty, native modules as a whole did not link and the problem is the
+        // build, not this package.
+        console.warn('[widget] linked native modules (' + all.length + '): ' + all.join(', '));
+      } else if (echo === json) {
+        console.log('[widget] App Group round-trip OK — container is writable by the app');
+      } else {
+        console.warn(
+          '[widget] native module present but read-back failed — likely not entitled to ' +
+            APP_GROUP +
+            ' (got ' +
+            String(echo) +
+            ')',
+        );
+      }
+    }
     return;
   }
 
@@ -102,17 +140,35 @@ export async function syncWidget(
   locale: string,
   nowMs: number = Date.now(),
 ): Promise<void> {
-  if (!supported) return;
+  if (!supported) {
+    if (__DEV__) console.log('[widget] skipped: unsupported runtime (Expo Go or web)');
+    return;
+  }
 
   const next = buildWidgetSnapshot(summary, targets, todayKey, nowMs, locale);
-  if (!widgetSnapshotChanged(lastWritten, next)) return;
+
+  // A zero calorie target is the single most common reason the widget sits on
+  // its empty state while everything else looks healthy: the Swift side treats
+  // `kcalTarget <= 0` as "nothing to show". Call it out rather than letting it
+  // look like a failed write.
+  if (__DEV__ && next.kcalTarget <= 0) {
+    console.warn('[widget] kcalTarget is 0 — the widget will render EMPTY by design', next);
+  }
+
+  if (!widgetSnapshotChanged(lastWritten, next)) {
+    if (__DEV__) console.log('[widget] unchanged since last write, skipping', next);
+    return;
+  }
 
   try {
     await persist(next);
     lastWritten = next;
-  } catch {
+    if (__DEV__) console.log('[widget] wrote snapshot + requested reload', next);
+  } catch (err) {
     // Leave `lastWritten` alone so the next call retries rather than assuming
-    // the failed write landed.
+    // the failed write landed. Swallowing this silently made a broken App Group
+    // write indistinguishable from never having written at all.
+    if (__DEV__) console.warn('[widget] write FAILED', err);
   }
 }
 

--- a/apps/mobile/src/widgets/TodayWidget.tsx
+++ b/apps/mobile/src/widgets/TodayWidget.tsx
@@ -35,7 +35,9 @@ const COLORS = {
 const ADD_ENTRY_URI = 'ignia://?openAdd=1';
 
 export function TodayWidget({ view }: { view: WidgetView }) {
-  const s = widgetStrings(view.state === 'ready' ? view.locale : 'en');
+  // Both states carry a locale now. This used to force 'en' for the empty
+  // state, so a Spanish user's home screen read "Open Ignia to start".
+  const s = widgetStrings(view.locale);
 
   return (
     <FlexWidget

--- a/apps/mobile/targets/widget/index.swift
+++ b/apps/mobile/targets/widget/index.swift
@@ -53,9 +53,11 @@ private struct Metric {
 
 /// Mirrors `WidgetView`. The empty reasons are collapsed into one case because
 /// iOS renders all three identically; the TS side keeps them apart only so its
-/// tests can distinguish them.
+/// tests can distinguish them. The locale rides along on BOTH cases — the empty
+/// state is a sentence, and hardcoding English here put "Open Ignia to start"
+/// on Spanish home screens.
 private enum View_ {
-  case empty
+  case empty(locale: String)
   case ready(kcal: Metric, protein: Metric, locale: String)
 }
 
@@ -70,10 +72,14 @@ private func loadView(now: Date) -> View_ {
     let data = raw.data(using: .utf8),
     let snap = try? JSONDecoder().decode(Snapshot.self, from: data),
     snap.v == snapshotVersion
-  else { return .empty }
+  else {
+    // Nothing readable, so there is no stored preference to honour — the one
+    // case where falling back to English is the only option.
+    return .empty(locale: "en")
+  }
 
-  guard snap.dateKey == localDateKey(now) else { return .empty }
-  guard snap.kcalTarget > 0 else { return .empty }
+  guard snap.dateKey == localDateKey(now) else { return .empty(locale: snap.locale) }
+  guard snap.kcalTarget > 0 else { return .empty(locale: snap.locale) }
 
   return .ready(
     kcal: Metric(consumed: snap.kcalConsumed, target: snap.kcalTarget),
@@ -175,7 +181,17 @@ private struct Provider: TimelineProvider {
 
   func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
     let now = Date()
-    var entries = [Entry(date: now, view: loadView(now: now))]
+    let current = loadView(now: now)
+    var entries = [Entry(date: now, view: current)]
+
+    // Carry today's locale into the post-midnight blank. Rebuilding it as "en"
+    // would flip a Spanish widget to English at midnight and leave it there
+    // until the app is next opened.
+    let locale: String
+    switch current {
+    case let .ready(_, _, l): locale = l
+    case let .empty(l): locale = l
+    }
 
     // Pre-schedule the rollover. The app calls `reloadWidget` on every log, so
     // in-day freshness is push-driven; this second entry exists for the one
@@ -187,7 +203,7 @@ private struct Provider: TimelineProvider {
       after: now, matching: DateComponents(hour: 0, minute: 0, second: 5),
       matchingPolicy: .nextTime)
     {
-      entries.append(Entry(date: midnight, view: .empty))
+      entries.append(Entry(date: midnight, view: .empty(locale: locale)))
     }
 
     // `.atEnd` asks WidgetKit for a new timeline once the last entry is passed,
@@ -206,8 +222,8 @@ private struct TodayWidgetView: SwiftUI.View {
     // protein. The ring is a deliberate fast-follow, not an omission.
     VStack(alignment: .leading, spacing: 0) {
       switch entry.view {
-      case .empty:
-        Text(strings("en").empty)
+      case let .empty(locale):
+        Text(strings(locale).empty)
           .font(.system(size: 13))
           .foregroundStyle(Color.igMuted)
 

--- a/packages/core/src/widget-snapshot.test.ts
+++ b/packages/core/src/widget-snapshot.test.ts
@@ -171,11 +171,17 @@ describe('widgetView', () => {
     expect(widgetView(snap({ dateKey: '2026-07-22' }), '2026-07-23')).toEqual({
       state: 'empty',
       reason: 'stale',
+      locale: 'en',
     });
   });
 
   it('blanks when nothing has been written yet', () => {
-    expect(widgetView(null, '2026-07-23')).toEqual({ state: 'empty', reason: 'no-snapshot' });
+    // No blob means no stored preference, so English is the only fallback.
+    expect(widgetView(null, '2026-07-23')).toEqual({
+      state: 'empty',
+      reason: 'no-snapshot',
+      locale: 'en',
+    });
   });
 
   it('blanks when onboarding never set a calorie target', () => {
@@ -183,6 +189,23 @@ describe('widgetView', () => {
     expect(widgetView(snap({ kcalTarget: 0, kcalConsumed: 0 }), '2026-07-23')).toEqual({
       state: 'empty',
       reason: 'no-targets',
+      locale: 'en',
+    });
+  });
+
+  it('keeps the snapshot locale on the empty states it can read one from', () => {
+    // The regression this guards: the renderers hardcoded English for every
+    // empty state, so a Spanish user's home screen read "Open Ignia to start"
+    // both after midnight and before onboarding finished.
+    expect(widgetView(snap({ dateKey: '2026-07-22', locale: 'es-PR' }), '2026-07-23')).toEqual({
+      state: 'empty',
+      reason: 'stale',
+      locale: 'es-PR',
+    });
+    expect(widgetView(snap({ kcalTarget: 0, locale: 'es-PR' }), '2026-07-23')).toEqual({
+      state: 'empty',
+      reason: 'no-targets',
+      locale: 'es-PR',
     });
   });
 

--- a/packages/core/src/widget-snapshot.ts
+++ b/packages/core/src/widget-snapshot.ts
@@ -102,7 +102,12 @@ export type WidgetEmptyReason =
   | 'no-targets';
 
 export type WidgetView =
-  | { state: 'empty'; reason: WidgetEmptyReason }
+  /** `locale` is carried here too: the empty state is a *sentence*, and the
+   *  renderers previously had nothing to key it off and so hardcoded English.
+   *  It is the snapshot's locale whenever a snapshot was readable, and falls
+   *  back to `'en'` only for `no-snapshot`, where there is genuinely nothing
+   *  to read a preference from. */
+  | { state: 'empty'; reason: WidgetEmptyReason; locale: string }
   | {
       state: 'ready';
       dateKey: string;
@@ -188,9 +193,11 @@ function metric(consumed: number, target: number): WidgetMetric {
  * outlives the day it was written for.
  */
 export function widgetView(snapshot: WidgetSnapshot | null, todayKey: string): WidgetView {
-  if (!snapshot) return { state: 'empty', reason: 'no-snapshot' };
-  if (snapshot.dateKey !== todayKey) return { state: 'empty', reason: 'stale' };
-  if (snapshot.kcalTarget <= 0) return { state: 'empty', reason: 'no-targets' };
+  if (!snapshot) return { state: 'empty', reason: 'no-snapshot', locale: 'en' };
+  if (snapshot.dateKey !== todayKey)
+    return { state: 'empty', reason: 'stale', locale: snapshot.locale };
+  if (snapshot.kcalTarget <= 0)
+    return { state: 'empty', reason: 'no-targets', locale: snapshot.locale };
   return {
     state: 'ready',
     dateKey: snapshot.dateKey,


### PR DESCRIPTION
Device QA of build `c539ab49` found the widget stuck on "Open Ignia to start". Two real bugs, both of which would have shipped in the same binary.

## 1. The widget never had data — `ExtensionStorage`'s native module wasn't in the binary

Every `set()` and `reloadWidget()` since install was a **no-op**. `@bacons/apple-targets` substitutes silent stubs when its native module is missing, so the JS logged a successful write on every meal while nothing was stored.

Root cause: no `ios.appleTeamId` in the Expo config — a documented prerequisite for that package, and the exact warning the build printed ("iOS builds may fail until this is corrected"). It was dismissed as cosmetic because the build succeeded. It did succeed; it just silently produced a binary without the module.

Ruled out first, so this isn't a guess at the layer:

- shared key + version match the Swift byte-for-byte
- `useWidgetSync` is mounted on Today and firing
- the snapshot carried a valid target (1760) and today's date key
- both bundle IDs have `APP_GROUPS` enabled in the Apple portal
- the package is a direct dependency, pinned to the same 5.0.0 the build used
- `expo-modules-autolinking` resolves it locally
- `expo-doctor` is clean apart from an unrelated expo patch mismatch

## 2. The empty state was hardcoded English — on both platforms

`index.swift` rendered `strings("en").empty`; `TodayWidget.tsx` passed `'en'` for anything not `ready`. The Spanish string existed in both tables and was simply unreachable, so a Spanish user saw "Open Ignia to start" on their home screen — before onboarding, and again after every midnight.

Fixed at the source rather than per renderer: `WidgetView`'s empty variant now carries `locale`, taken from the snapshot whenever one was readable. Only `no-snapshot` falls back to English. iOS also carries it into the pre-scheduled midnight entry, which would otherwise have flipped a Spanish widget at midnight and left it wrong until the app was next opened.

Same class as the date-localization fix already waiting in §2.

## Diagnostics kept

The `__DEV__` probes that found this are retained. A bare `catch {}` on the one path with no UI is what let a dead feature look healthy for a whole build cycle. They now distinguish *native module missing* / *not entitled to the App Group* / *wrote fine* — three different fixes that previously looked identical. All `__DEV__`-gated, so they cost nothing in a production binary.

## Verification

529 core tests (one added, covering both readable empty states in es-PR), mobile typecheck, web build, 191 web tests.

Build `de8fabd0` finished from this branch. The retained probe reports the linking result on first launch — that is the confirmation this fix works, and it cannot be checked from Windows (`expo prebuild -p ios` is skipped there in SDK 54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
