### PR TITLE
feat(watch): build the Apple Watch complication and its transport

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -505,6 +505,29 @@ the same name under `src/app/components/`.
   flare; streak extended → flame-chip animation). Distinct from ambient
   motion (entrances, press-springs), which is not event-tied. No
   confetti/mascot layer by decision.
+- **Widget snapshot** — The ~150-byte glanceable blob defined by
+  `packages/core/src/widget-snapshot.ts`: today's kcal/protein consumed
+  and target, the `dateKey` staleness guard, and the locale. **One term
+  for the blob no matter which surface reads it.** The name says "widget"
+  because the stored key `ignia.widget.snapshot.v1` cannot change without
+  orphaning the blob the already-installed home-screen widget is reading;
+  renaming the symbol alone would leave a `Glance*` constant pointing at a
+  `"widget"` string, which is more drift, not less
+  ([#38](https://github.com/gabandres/fitness-tracker-pwa/issues/38) §6).
+- **Glanceable surface** — Any renderer of the widget snapshot: the iOS
+  home-screen widget, the three iOS Lock Screen accessory families, the
+  Android home-screen widget, the Apple Watch complication, and the watch
+  mirror screen. They differ in layout and in empty-state copy; they never
+  differ in the decode, the version gate, or the staleness rule. On Apple
+  those shared rules live in exactly one file,
+  `apps/mobile/targets/_shared/Glance.swift`.
+- **Watch mirror screen** — The Apple Watch app's single read-only screen.
+  A **reader** of the widget snapshot, not an exception to it: it adds no
+  fields and shows the denominators (`1,240 / 2,000`) the face has no room
+  for. It is also **link 2 of the watch transport** — WatchConnectivity
+  delivers to the watch *app*, never to a complication — so it exists even
+  when nobody opens it
+  ([#39](https://github.com/gabandres/fitness-tracker-pwa/issues/39)).
 
 ## Platforms (post-#12 — see [ADR-0012](docs/adr/0012-expo-native-app-shared-core.md))
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # STATUS — what is true right now
 
-**Updated:** 2026-08-02 · **Owns:** current state only. Not history (`CHANGELOG.md`),
+**Updated:** 2026-08-03 · **Owns:** current state only. Not history (`CHANGELOG.md`),
 not rationale (`docs/adr/`), not vocabulary (`CONTEXT.md`).
 
 If a statement here conflicts with any other file in this repo, **this file wins** —
@@ -50,7 +50,7 @@ re-scope it as new work; do not describe it to users as available.
   its task handler registers through the custom `index.js` — a path no device has
   exercised. **The iOS widget is no longer in this list: it is verified working
   on a physical iPhone from TestFlight build 13 (2026-08-03), including refresh
-  after a meal.** See §4 #36.
+  after a meal.**
 - **The Apple Watch complication and its transport** — the watch app
   (`targets/watch/`), the face complication (`targets/watch-widget/`), the
   three iOS **Lock Screen** accessory families, one shared Swift contract
@@ -91,10 +91,19 @@ review those commits fixed.
 
 - iOS cannot be built on this machine. Windows, no Xcode. There is no local path.
 - iOS builds come from **EAS cloud, free tier**: 15 iOS builds/month, low-priority
-  queue, 1 concurrent, 45-minute timeout.
-- **The quota reset landed. iOS 2/15, Android 1/15 for the 2026-08-01 →
-  2026-09-01 period — measured 2026-08-02 from the API.** The counter is not the
+  queue, 1 concurrent, 45-minute timeout. There are **two** ceilings, not one —
+  a **30/month account total** and a **15/month per platform** sub-cap. Read
+  both; the account total is the one that runs out first if the two platforms
+  are used unevenly.
+- **iOS 5/15, Android 3/15, account 8/30 for the 2026-08-01 → 2026-09-01
+  period — measured 2026-08-03 from the API.** The counter is not the
   constraint this period.
+- **The queue is the real cost, and it is not metered.** An Android build on
+  2026-08-03 waited **2h05m** for a worker, ran Gradle for five minutes, and
+  died on an HTTP 401 from Sentry's source-map upload. Both the build and the
+  afternoon were gone. **Anything knowable before submitting must be checked
+  before submitting** — `npm run doctor` now validates `SENTRY_AUTH_TOKEN`
+  against the Sentry API for exactly this reason.
 
 ```sh
 cd apps/mobile && npx eas-cli account:usage gabandres --non-interactive
@@ -197,9 +206,9 @@ cd apps/mobile && npx eas-cli build:list --platform ios --limit 5   # what exist
 | # | Work | Blocked on |
 |---|---|---|
 | — | Next iOS binary (everything in §2) | Nothing structural. Build 13 exists, is on TestFlight, and its widget is verified on device — the device-QA gate this row used to name is **cleared**. What remains is submitting the 1.1.0 version page to App Review (it is still `PREPARE_FOR_SUBMISSION`), or cutting a newer build first if more of §2 should ride along. Quota and credentials are both resolved |
-| #36 | Verify the shipped widget on a physical iPhone | **DONE — 2026-08-03, on a real iPhone home screen from TestFlight build 13.** It renders kcal left and protein left, **and the numbers moved after logging a meal**, which is the part that proves the whole chain: app write → App Group → `ExtensionStorage` → widget refresh. Not a render-only check. The iOS half of §3's `ExtensionStorage` saga is closed; the deployment-target fix worked in a production binary. **Still unverified: the Android widget** — it is in Play vc 4 (in review), and its task handler registers through the custom `index.js`, a path no device has exercised |
+| — | Verify the **Android** widget on a device | Nobody has put it on an Android home screen. It is in Play vc 4, and its task handler registers through the custom `index.js` — a path no device has exercised. The iOS half is **done**: verified on a real iPhone 2026-08-03 from TestFlight build 13, kcal left + protein left, **and the numbers moved after a logged meal**, which proves the whole chain rather than the render alone |
 | #46 | Read the watch layouts on a simulator | **a Mac with Xcode** (currently: borrow one). Its stated precondition — "the build session has written the watch Swift" — is now **met**: the real layouts exist, so the sitting is the readout it was designed to be |
-| #47 | Compile the generated watch targets in Xcode | **a Mac with Xcode.** Now runs against **real code instead of stubs**: `targets/_shared/Glance.swift` is referenced from all three Apple targets, so the `_shared` membership question (#38's load-bearing one) is answered by whether the project builds, with no `ProbeShared.swift` needed. `probe/watch-compile-47` is superseded by `feat/watch-complication`; keep it only for the throwaway `ViewThatFits` probe |
+| #47 | Compile the generated watch targets in Xcode | **a Mac with Xcode.** Now runs against **real code instead of stubs**: `targets/_shared/Glance.swift` is referenced from all three Apple targets, so the `_shared` cross-target membership question — the load-bearing one for holding the Swift mirror at a single copy — is answered by whether the project builds, with no `ProbeShared.swift` needed. `probe/watch-compile-47` is superseded by `feat/watch-complication`; keep it only for the throwaway `ViewThatFits` probe |
 | — | App Store screenshots | owner, on device (`store-assets/README.md`) |
 | — | Play launch — **first AAB** | **DONE** (2026-08-02). Local `bundleRelease` is **permanently dead on this machine**: `LongPathsEnabled=1` and a reboot changed nothing, because the cap is **ninja**, not the registry — the SDK's `cmake/3.22.1/bin/ninja.exe` is not long-path-aware, and the `react-native-keyboard-controller` object path is 348 chars. Relocating `.cxx` cannot save it (the CMake target-dir prefix alone is 105 chars). **AABs come from EAS.** `eas.json` `production` now sets `android.credentialsSource: "local"` so EAS signs with `credentials/dev.keystore` instead of minting a new upload key — **that line is load-bearing; removing it silently changes app identity.** Artifact: EAS build `4b513a00`, vc 3, signer SHA-256 `75:4B:03:19:…:F6:D8` |
 | — | Play launch — **upload the AAB to a closed track** | **DONE** (2026-08-02). vc 4 is on Closed testing - Alpha and submitted; the app is in Google review. Play does not accept an app's *first* upload through the Developer API, so this one went through the console UI. **vc 3 was discarded, not shipped** — it declared three health READ permissions the app never requests, and Play's health declaration demands a written justification per read permission. `07ce8e99` removed them; vc 4 declares 11 health permissions (5 read, 6 write). Do not resurrect vc 3 |
@@ -215,7 +224,7 @@ cd apps/mobile && npx eas-cli build:list --platform ios --limit 5   # what exist
 
 **Apple glanceable surfaces (map #31).** 14 of its 16 tickets are **closed** —
 transport, staleness, layouts, tap targets, review surface and sign-out privacy
-were decided first, and #36 closed 2026-08-03 on device. What remains is
+were decided first, and the on-device widget verification closed 2026-08-03. What remains is
 **#46 and #47, both of which need a Mac** — the two things on the whole map that
 cannot be done on this machine.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -51,6 +51,19 @@ re-scope it as new work; do not describe it to users as available.
   exercised. **The iOS widget is no longer in this list: it is verified working
   on a physical iPhone from TestFlight build 13 (2026-08-03), including refresh
   after a meal.** See §4 #36.
+- **The Apple Watch complication and its transport** — the watch app
+  (`targets/watch/`), the face complication (`targets/watch-widget/`), the
+  three iOS **Lock Screen** accessory families, one shared Swift contract
+  (`targets/_shared/Glance.swift`), and the repo's first custom Expo Module
+  (`modules/watch-link/`) carrying the snapshot over
+  `WCSession.updateApplicationContext`. **None of it has ever been
+  compiled** — Windows, no Xcode, and `expo prebuild -p ios` does not run
+  here. What *was* verified locally: `tsc` clean, both `expo-target.config.js`
+  files evaluate to the right entitlements, and
+  `expo-modules-autolinking search -p apple` resolves `watch-link` →
+  `WatchLinkModule` (the check that would have caught the `ExtensionStorage`
+  disappearance in §3). Blocked on a Mac for #46/#47, and on a `production`
+  credentials pass for two brand-new bundle ids.
 - **Health activity import** (steps / active energy → `dailyActivity`). Import +
   display only; deliberately does **not** feed measured-mode TDEE.
 - **Per-meal reminder settings** (fixes the un-silenceable 1:30pm lunch nudge).
@@ -185,8 +198,8 @@ cd apps/mobile && npx eas-cli build:list --platform ios --limit 5   # what exist
 |---|---|---|
 | — | Next iOS binary (everything in §2) | Nothing structural. Build 13 exists, is on TestFlight, and its widget is verified on device — the device-QA gate this row used to name is **cleared**. What remains is submitting the 1.1.0 version page to App Review (it is still `PREPARE_FOR_SUBMISSION`), or cutting a newer build first if more of §2 should ride along. Quota and credentials are both resolved |
 | #36 | Verify the shipped widget on a physical iPhone | **DONE — 2026-08-03, on a real iPhone home screen from TestFlight build 13.** It renders kcal left and protein left, **and the numbers moved after logging a meal**, which is the part that proves the whole chain: app write → App Group → `ExtensionStorage` → widget refresh. Not a render-only check. The iOS half of §3's `ExtensionStorage` saga is closed; the deployment-target fix worked in a production binary. **Still unverified: the Android widget** — it is in Play vc 4 (in review), and its task handler registers through the custom `index.js`, a path no device has exercised |
-| #46 | Read the watch layouts on a simulator | **a Mac with Xcode** (currently: borrow one) |
-| #47 | Compile the generated watch targets in Xcode | **a Mac with Xcode**; branch `probe/watch-compile-47` stages it |
+| #46 | Read the watch layouts on a simulator | **a Mac with Xcode** (currently: borrow one). Its stated precondition — "the build session has written the watch Swift" — is now **met**: the real layouts exist, so the sitting is the readout it was designed to be |
+| #47 | Compile the generated watch targets in Xcode | **a Mac with Xcode.** Now runs against **real code instead of stubs**: `targets/_shared/Glance.swift` is referenced from all three Apple targets, so the `_shared` membership question (#38's load-bearing one) is answered by whether the project builds, with no `ProbeShared.swift` needed. `probe/watch-compile-47` is superseded by `feat/watch-complication`; keep it only for the throwaway `ViewThatFits` probe |
 | — | App Store screenshots | owner, on device (`store-assets/README.md`) |
 | — | Play launch — **first AAB** | **DONE** (2026-08-02). Local `bundleRelease` is **permanently dead on this machine**: `LongPathsEnabled=1` and a reboot changed nothing, because the cap is **ninja**, not the registry — the SDK's `cmake/3.22.1/bin/ninja.exe` is not long-path-aware, and the `react-native-keyboard-controller` object path is 348 chars. Relocating `.cxx` cannot save it (the CMake target-dir prefix alone is 105 chars). **AABs come from EAS.** `eas.json` `production` now sets `android.credentialsSource: "local"` so EAS signs with `credentials/dev.keystore` instead of minting a new upload key — **that line is load-bearing; removing it silently changes app identity.** Artifact: EAS build `4b513a00`, vc 3, signer SHA-256 `75:4B:03:19:…:F6:D8` |
 | — | Play launch — **upload the AAB to a closed track** | **DONE** (2026-08-02). vc 4 is on Closed testing - Alpha and submitted; the app is in Google review. Play does not accept an app's *first* upload through the Developer API, so this one went through the console UI. **vc 3 was discarded, not shipped** — it declared three health READ permissions the app never requests, and Play's health declaration demands a written justification per read permission. `07ce8e99` removed them; vc 4 declares 11 health permissions (5 read, 6 write). Do not resurrect vc 3 |
@@ -200,11 +213,28 @@ cd apps/mobile && npx eas-cli build:list --platform ios --limit 5   # what exist
 | — | Play launch — **delete-account URL** | **DONE and LIVE.** Verified 2026-08-01 and it *failed* — signed out, the page said only "sign in first to delete your account". `fb7d24d1` adds an unconditional "How to delete your account" section (iOS path, web path, and an email path for users who can't sign in) plus what is erased vs. what survives in backups, both locales. Deployed to `ignia.fit/privacy` and confirmed in a browser |
 | — | Play launch — **store listing graphics** | **DONE.** `scripts/play-store-assets.mjs` generates all of them from artwork already in the repo → `store-assets/play/`. Play needs 16:9 or 9:16 and the captures are 1:2.17, so each is fitted onto a 1080×1920 canvas in the brand panel colour (the art already sits on that colour, so the letterboxing is invisible). Icon 512², feature graphic 1024×500, five phone screenshots — all uploaded and saved |
 
-**Apple glanceable surfaces (map #31).** 13 of its 16 tickets are **closed** — the
-transport, staleness, layouts, tap targets, review surface and sign-out privacy are
-all decided. What remains is #36/#46/#47 above. No watch Swift exists yet;
-`apps/mobile/targets/` contains only `widget` (the stubs were removed in `f4f03f38`
-until the work starts). "Mostly done" describes the deciding, not the building.
+**Apple glanceable surfaces (map #31).** 14 of its 16 tickets are **closed** —
+transport, staleness, layouts, tap targets, review surface and sign-out privacy
+were decided first, and #36 closed 2026-08-03 on device. What remains is
+**#46 and #47, both of which need a Mac** — the two things on the whole map that
+cannot be done on this machine.
+
+The building is done. `apps/mobile/targets/` now holds `_shared`, `widget`,
+`watch` and `watch-widget`, plus `apps/mobile/modules/watch-link` for the phone
+half of the transport. **What is unproven is narrow and specific: none of that
+Swift has ever been through a compiler.** Do not read "written" as "works" — the
+iPhone widget was written, merged, and silently broken for two builds because a
+pod never linked.
+
+**The credentials gate is real and is not the Mac.** The scheme gains **two new
+bundle ids** (`fit.ignia.app.watchkitapp` and
+`fit.ignia.app.watchkitapp.complication`), neither of which exists in the Apple
+portal. §3 already records that EAS cannot mint those unattended — it refuses in
+non-interactive mode, and the failing call is a Developer Portal write where EAS
+falls back to Apple ID session auth and asks for `EXPO_APPLE_ID` + 2FA, which no
+ASC API key covers. `production` still has not had its interactive pass; this
+adds two more ids to it. Credential failures cost **no build quota** — they
+happen before the build is created.
 
 ## 5. Decided and deliberately not happening
 

--- a/apps/mobile/WIDGET.md
+++ b/apps/mobile/WIDGET.md
@@ -1,16 +1,20 @@
-# Home-screen Widget — design, seams and device QA
+# Glanceable surfaces — design, seams and device QA
 
-> **This file owns the widget's *design*: how it gets its data, what was
-> decided, and how to verify it on hardware. It does not track state.** Whether
-> the widget is built, in a binary, or verified is in **`STATUS.md`**, which has
-> the command to re-check. Do not restate build or quota status here — this doc
-> carried a "BUILT, unverified" banner and an EAS quota date, and both were the
-> kind of claim that goes stale silently.
+> **This file owns the *design* of every surface that renders the widget
+> snapshot: how it gets its data, what was decided, and how to verify it on
+> hardware. It does not track state.** Whether a surface is built, in a binary,
+> or verified is in **`STATUS.md`**, which has the command to re-check. Do not
+> restate build or quota status here — this doc carried a "BUILT, unverified"
+> banner and an EAS quota date, and both were the kind of claim that goes stale
+> silently.
 
-Scope: a home-screen widget showing **today's calories + protein remaining**
-(and optionally a small ring), refreshed from a last-known snapshot the app
-writes on each log. Runtime cost: **$0** (reads local shared storage, no
-network, no Cloud Function).
+Scope: **today's calories + protein remaining**, on every surface that can show
+them without opening the app — the iOS home-screen widget, the three iOS Lock
+Screen accessory families, the Android home-screen widget, the Apple Watch
+complication, and the watch's one read-only screen. All render the same
+last-known snapshot the app writes on each log. Runtime cost: **$0** (local
+shared storage and, on the watch, WatchConnectivity — no network, no auth, no
+Cloud Function anywhere in the chain).
 
 Expo has **no built-in widget support** — widgets are OS-native extensions, so
 this is the most native-heavy of the pipeline features (iOS needs Swift).
@@ -53,12 +57,16 @@ state (the app hasn't been opened yet today) rather than stale numbers.
   target to the managed Expo project without ejecting. The widget UI is
   **SwiftUI** (Swift, hand-written — there's no JS escape hatch on iOS).
 - **Shared storage:** an **App Group** (`group.fit.ignia.app`). The RN side
-  writes the snapshot JSON to the App Group's shared `UserDefaults` (or a file
-  in the group container); the Swift widget reads the same key. Bridge from RN
-  via a tiny native module or `react-native-shared-group-preferences`.
-- **Refresh:** WidgetKit `TimelineProvider` — reload on our write via
-  `WidgetCenter.shared.reloadAllTimelines()` (call from the native module after
-  each snapshot write) + a periodic timeline entry as a backstop.
+  writes the snapshot JSON to the App Group's shared `UserDefaults` via
+  `ExtensionStorage` (from `@bacons/apple-targets`); the Swift widget reads the
+  same key back.
+- **Refresh:** WidgetKit `TimelineProvider` — `ExtensionStorage.reloadWidget`
+  on our write, plus a pre-scheduled midnight entry as the backstop for the one
+  moment nothing pushes.
+- **Families:** `.systemSmall` on the Home Screen, and
+  `.accessoryCircular` / `.accessoryRectangular` / `.accessoryInline` on the
+  Lock Screen. `.accessoryCorner` is deliberately absent — it is the only family
+  with no Lock Screen counterpart, so it would be the only net-new layout.
 - **Owner gate:** the widget-extension target + App Group capability must be
   registered on the `fit.ignia.app` App id in the Apple Developer portal.
 
@@ -71,6 +79,47 @@ state (the app hasn't been opened yet today) rather than stale numbers.
   snapshot on log change; call the library's `requestWidgetUpdate` after writes.
 - **Refresh:** on-demand via `requestWidgetUpdate` + an `updatePeriodMillis`
   backstop (Android clamps this to ≥30 min — fine for a "remaining" display).
+
+## Apple Watch
+
+The complication is the same shape as the iPhone widget, one hop further out —
+and that hop is the whole design problem. **App Groups are per-device**, so the
+watch cannot read the container the phone writes. Decisions live on the #31 map
+(#33, #37, #38, #39, #40, #43, #44); this is the shape they landed on.
+
+- **Transport:** `WCSession.updateApplicationContext` and nothing else. Latest-
+  wins, $0, no auth. Reading Firestore on the watch is **structurally
+  unavailable** — Firebase's own platform matrix has a blank watchOS cell for
+  Cloud Firestore. WidgetKit push carries no payload. `sendMessage` does not
+  wake the counterpart.
+- **The payload is a one-key envelope** carrying the *already-serialized*
+  snapshot JSON, byte-identical to what `ExtensionStorage` writes. Sending the
+  eight fields as a native dictionary would have created a second decode path in
+  Swift and made the dictionary's key set a third thing to keep in step.
+- **The watch app is link 2 of the transport, not decoration.** WatchConnectivity
+  delivers to the app, never to a complication, so the app owns the `WCSession`
+  delegate, the `.backgroundTask(.watchConnectivity)`, the App Group write and
+  the `reloadAllTimelines`. Its one screen is additive to a job it must do
+  regardless — and a watch binary whose only screen is empty is the
+  minimum-functionality shape that has already cost this app two rejections.
+- **The delegate writes blindly; the guard runs at render.** One guard
+  implementation means the screen and the face can never disagree about what
+  "stale" means, and on a transient two-clock disagreement a validating delegate
+  would discard the only copy of data it has no way to re-request. There is no
+  pull on this transport.
+- **How fresh it honestly is:** seconds-to-minutes with the watch on the wrist
+  and the phone in pocket; 15–60 minutes once the day's reloads throttle;
+  **unbounded** while the two devices are apart. Apple promises no latency at
+  all. That ceiling is why the rectangular face carries an unconditional
+  `as of 8:04 AM` and the watch screen always does — and why there is no refresh
+  affordance anywhere on the watch.
+- **Sign-out** pushes an empty envelope, which fails the decode and collapses to
+  the same empty face as an absent blob. The honest bound is *cleared on next
+  contact, or at the watch's local midnight, whichever comes first* — the
+  day-key guard is a privacy backstop, not just a freshness one.
+- **`deploymentTarget: "10.0"`, pinned on both watch targets.** 9.4 looks free
+  and is not: it sits below the line where the **Smart Stack** exists, which is
+  where an Apple Watch widget is actually discovered today.
 
 ## Shared work (both platforms)
 - `packages/core/src/widget-snapshot.ts` + unit tests (pure; export from
@@ -128,14 +177,37 @@ screen.
 - [ ] Sign out → the widget blanks (it must not keep the old account's numbers
       on the home screen).
 
+**Apple Watch** — none of this is reachable until the watch targets compile and
+a build carries them. The layout half is a **simulator** readout (#46) and needs
+no hardware; everything below needs a real paired watch.
+
+- [ ] Complication appears in the face gallery (Smart Stack presence is the
+      whole reason for the `10.0` pin).
+- [ ] Add it with the phone having **never pushed** → `Waiting for iPhone`, not
+      zeros, and the watch screen carries the explanatory subline.
+- [ ] Log a meal with the watch on the wrist and phone in pocket → the face
+      moves. **This is the one that matters** — it proves the whole hop, not
+      just the render, the same way the iPhone check did.
+- [ ] Tap the face → the mirror screen opens and shows the denominators
+      (`1,240 / 2,000`, `protein 88/150`) plus `as of`.
+- [ ] Walk out of range, log on the phone, come back → the face catches up on
+      next contact. (Latency here is unmeasurable by design; the check is that
+      it *converges*, not how fast.)
+- [ ] Cross midnight with the two devices apart → the face blanks. This is the
+      privacy backstop, not just freshness.
+- [ ] Sign out with the watch nearby → the face blanks on next contact.
+- [ ] Sign out with the watch **in a drawer** → it stays populated until local
+      midnight. That is the documented bound, not a bug; confirm it is the
+      bound and not "forever".
+
 ## Locked decisions
 Settled 2026-07-23, before any code existed.
 
 | Decision | Locked as |
 |---|---|
-| **What it shows** | **kcal remaining + protein remaining, text-first.** No ring — it's a fast-follow once the seam is proven on device. |
+| **What it shows** | **kcal remaining + protein remaining, text-first.** The home-screen faces stay text-first and still ignore `progress`; the ring arrived later, on the accessory families, where a `Gauge` is the whole idiom. |
 | **Platforms** | **Both.** Android's TSX widget is cheap and validates the snapshot pipeline before the Swift cost is paid; nothing ships on Play until the 12-tester gate is met. |
-| **Sizes** | **iOS `.systemSmall` / Android 2×2 only.** Medium is additive later. |
+| **Sizes** | **iOS `.systemSmall` / Android 2×2** for the home screen; `systemMedium` is still additive later. The Lock Screen and watch accessory families were added afterwards and are governed by the #31 map, not by this table. |
 | **Tap target** | **Deep-link to the add-entry sheet** (`ignia://?openAdd=1` — the same param the in-app FAB route uses), so the widget drives logging. |
 | **Empty state** | **"Open Ignia to start."** Never zeros — a "0 left" reads as a fully-eaten day. |
 | **Theme** | **One fixed brand face, dark in both themes** (the `heroPanel` family, ADR-0014). A widget sits on the wallpaper and can't follow the in-app theme. |
@@ -149,14 +221,31 @@ Settled 2026-07-23, before any code existed.
 | `apps/mobile/src/lib/widget.ts` | Storage + reload adapter. iOS → App Group `UserDefaults` via `ExtensionStorage`; Android → `AsyncStorage` + `requestWidgetUpdate`. Native modules lazy-required (Expo Go / web safe). |
 | `apps/mobile/src/hooks/useWidgetSync.ts` | Mounted on Today. Writes on every summary/target change + on app foreground. No new Firestore listeners (ADR-0016). |
 | `apps/mobile/src/widgets/*` | Android widget UI (TSX), string table, task handler. |
-| `apps/mobile/targets/widget/index.swift` | iOS SwiftUI widget — the hand-written Swift **mirror** of `widget-snapshot.ts`. |
+| `apps/mobile/targets/_shared/Glance.swift` | **The one Swift mirror** of `widget-snapshot.ts` — decode, version gate, staleness guard, `Metric`, the contract constants and the string table. The apple-targets plugin globs `_shared/*` and links it into **every** target, so this single file reaches the widget, the watch app and the complication. |
+| `apps/mobile/targets/widget/index.swift` | iOS SwiftUI widget: `systemSmall` + the three accessory families. Views and `TimelineProvider` only. |
+| `apps/mobile/targets/watch/index.swift` | watchOS app — `WCSession` delegate, background task, App Group write, `reloadAllTimelines`, and the one read-only mirror screen. |
+| `apps/mobile/targets/watch-widget/index.swift` | Watch face complication: circular, rectangular, inline. |
+| `apps/mobile/modules/watch-link/` | The phone half of the transport. A custom Expo Module — the repo's first — that forwards the envelope over `WCSession`. Deliberately a dumb pipe: it never learns the contract, and it cannot see `_shared` (Expo Modules are CocoaPods targets, not apple-targets). |
 | `apps/mobile/index.js` | Custom entry; registers the Android task handler before React mounts. |
 
-**The mirroring is the thing to watch.** iOS can't run our JS, so the decode /
-staleness / over-vs-left rules exist twice. `widget-snapshot.ts` is the spec and
-its vitest suite is the reference; a change to one side is a bug until it lands
-on the other. The same applies to the widget string table (`strings.ts` ↔ the
-`strings()` func in `index.swift`) and the palette hexes.
+**The mirroring is the thing to watch, and it is held at exactly one copy.**
+iOS can't run our JS, so the decode / staleness / over-vs-left rules exist
+twice — in `widget-snapshot.ts` and in `Glance.swift` — and **not once per
+Apple surface**. `widget-snapshot.ts` is the spec and its vitest suite is the
+reference; a change to one side is a bug until it lands on the other. Android
+keeps its own table in `strings.ts` because it renders in JS. Two tables total,
+not three.
+
+**Views are deliberately NOT shared.** The `_shared` group is linked into the
+*main app* target too, so everything in it compiles against the phone app's iOS
+floor — `Gauge` is iOS 16+, `.containerBackground` is iOS 17+, and shared
+SwiftUI would need `@available` guards on code that can only be compiled by
+spending an EAS build. The dividing line, stated once: **what can silently show
+wrong _numbers_ is shared; what can only look wrong is not.** A drifted layout
+is visible to anyone who looks at it; a drifted staleness guard is not.
+
+**Prebuild must be re-run on any add/rename/remove in `targets/_shared/`** — the
+glob runs at prebuild time and is non-recursive (one level).
 
 ### Locale rides in the blob
 Our locale is `profile.preferredLocale` — behind auth and Firestore, neither of
@@ -167,6 +256,12 @@ the snapshot and each widget keeps its own small string table.
 ## Deferred / separate (NOT this plan)
 - **Fasting Live Activity** (iOS lock-screen fast countdown) — natural given the
   existing Fasting feature, but a distinct ActivityKit effort (~1 wk, iOS-only).
-- **Apple Watch complication / app** — separate target, larger.
 - **Interactive widgets** (log from the widget without opening the app) —
-  iOS 17+ AppIntents; defer until the display widget ships.
+  iOS 17+ AppIntents; defer until the display widget ships. Note this is a
+  different thing from a quick-log affordance *on the watch*, which was
+  separately rejected: it needs a watch→phone write path this design does not
+  have.
+- **`.accessoryCorner`** — the one accessory family not shipped. Absent from the
+  corner slots of the Infograph faces is the accepted cost.
+- **Wear OS** — Android glanceable surfaces beyond the home-screen widget are
+  out of scope on the #31 map.

--- a/apps/mobile/modules/watch-link/expo-module.config.json
+++ b/apps/mobile/modules/watch-link/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+  "platforms": ["apple"],
+  "apple": {
+    "modules": ["WatchLinkModule"]
+  }
+}

--- a/apps/mobile/modules/watch-link/index.ts
+++ b/apps/mobile/modules/watch-link/index.ts
@@ -1,0 +1,55 @@
+import { requireOptionalNativeModule } from 'expo';
+
+/**
+ * WatchLink — the TS face of the one-function WatchConnectivity bridge in
+ * `ios/WatchLinkModule.swift`.
+ *
+ * `requireOptionalNativeModule` rather than `requireNativeModule`: this module
+ * is iOS-only and is absent from the Android binary, from Expo Go and from the
+ * web bundle. An optional require makes every call below a silent no-op there,
+ * which is the same shape `src/lib/health.ts` and `src/lib/widget.ts` already
+ * use for native surfaces that do not exist on every runtime.
+ *
+ * There is no listener API and there never should be: the phone asserts, the
+ * watch receives. Nothing flows back (#37 §3).
+ */
+
+interface WatchLinkModule {
+  /** Whether this device can hold a `WCSession` at all (false on iPad). */
+  readonly isSupported: boolean;
+  /** Only meaningful once the session has activated; false otherwise. */
+  readonly isPaired: boolean;
+  readonly isWatchAppInstalled: boolean;
+  /** True when something was handed to the system; false when there was
+   *  nothing to send to, or the counterpart already held exactly this. */
+  updateApplicationContext(record: Record<string, string>): boolean;
+}
+
+const native = requireOptionalNativeModule<WatchLinkModule>('WatchLink');
+
+/** True when the native module is linked into this binary. */
+export const isWatchLinkAvailable = native != null;
+
+export function isPaired(): boolean {
+  return native?.isPaired ?? false;
+}
+
+export function isWatchAppInstalled(): boolean {
+  return native?.isWatchAppInstalled ?? false;
+}
+
+/**
+ * Assert what the wrist should show.
+ *
+ * Latest-wins and never queues, so over-calling is cheap; the native side also
+ * skips the send when the counterpart already holds exactly this record, which
+ * is what keeps the watch's 40–75/day reload budget untouched in the steady
+ * state.
+ *
+ * Never throws. `WCError.deviceNotPaired` / `.watchAppNotInstalled` are the
+ * ordinary case on a watch-less iPhone, not a fault, and are swallowed
+ * natively (#44 §5.3).
+ */
+export function updateApplicationContext(record: Record<string, string>): boolean {
+  return native?.updateApplicationContext(record) ?? false;
+}

--- a/apps/mobile/modules/watch-link/ios/WatchLink.podspec
+++ b/apps/mobile/modules/watch-link/ios/WatchLink.podspec
@@ -1,0 +1,30 @@
+Pod::Spec.new do |s|
+  s.name           = 'WatchLink'
+  s.version        = '1.0.0'
+  s.summary        = 'One-function WatchConnectivity bridge for the Ignia watch complication.'
+  s.description    = 'Pushes the already-serialized widget snapshot to the paired Apple Watch via WCSession.updateApplicationContext. See ios/WatchLinkModule.swift.'
+  s.author         = 'Ignia'
+  s.homepage       = 'https://ignia.fit'
+  s.license        = { :type => 'MIT' }
+  s.source         = { :git => '' }
+  s.static_framework = true
+
+  # DO NOT raise this above the app's `ios.deploymentTarget` in app.json (16.4).
+  #
+  # Expo's autolinking SILENTLY DROPS a module whose podspec floor sits above
+  # the app's deployment target — no warning, no build failure, the pod simply
+  # never exists and every call becomes a no-op. That is exactly how the
+  # `ExtensionStorage` pod went missing and killed the iPhone widget for two
+  # builds (STATUS.md §3). Keeping this comfortably below the app floor means
+  # the trap cannot re-arm from this side.
+  s.platforms      = { :ios => '15.1' }
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = "**/*.{h,m,mm,swift,hpp,cpp}"
+end

--- a/apps/mobile/modules/watch-link/ios/WatchLinkModule.swift
+++ b/apps/mobile/modules/watch-link/ios/WatchLinkModule.swift
@@ -1,0 +1,172 @@
+import ExpoModulesCore
+import WatchConnectivity
+
+//
+//  WatchLink — the phone half of the watch transport. One function.
+//
+//  ## Why this is hand-written and not a package
+//
+//  `react-native-watch-connectivity@2.0.0` is a genuine TurboModule on a
+//  supported RN floor, and was still rejected: it ships **no `app.plugin.js`**
+//  and the author claims only "Bare Workflow with EAS Build", so autolinking
+//  under SDK 54 CNG prebuild is unverified. EAS iOS builds are the scarce
+//  resource here, not money, and discovering an autolink failure costs one. A
+//  first-party Expo Module autolinks by construction (#37 §3).
+//
+//  The tradeoff accepted: we own this Swift across SDK bumps. It is one
+//  function.
+//
+//  ## It is a dumb pipe, on purpose
+//
+//  This module never learns the snapshot contract. It forwards a dictionary
+//  from JS and compares it against what was last sent. The wire shape, the key
+//  names, the version gate and the staleness rule all live in
+//  `packages/core/src/widget-snapshot.ts` and its Swift mirror
+//  `targets/_shared/Glance.swift`, neither of which this pod can see — Expo
+//  Modules are CocoaPods targets, not apple-targets. Under this design it does
+//  not need to (#38, consequence A).
+//
+//  ## It returns rather than throws
+//
+//  `WCSession` on an iPhone activates fine with no watch paired, and then
+//  raises `WCError.deviceNotPaired` / `.watchAppNotInstalled` on send. That is
+//  the **normal** case on most installs, not an edge case. A dumb pipe that
+//  throws on every watch-less iPhone is a trap, and pushing the guard into JS
+//  would mean re-deriving watch-pairing state on the TS side — exactly the
+//  knowledge this module exists to hold (#44 §5.3).
+//
+//  Note `isPaired` cannot serve as a pre-check: Apple documents it as "only
+//  valid when the session's activationState is .activated".
+//
+
+private final class WatchLinkSession: NSObject, WCSessionDelegate {
+  static let shared = WatchLinkSession()
+
+  /// The last context JS asked us to assert. Held in memory so it can be
+  /// re-asserted on the two transitions that create a delivery hole: session
+  /// activation, and the watch being paired or the watch app installed while
+  /// this process is alive (#39 §4).
+  ///
+  /// The model in one line: **the phone asserts what the wrist should show, on
+  /// every activation. When there is no session, the answer is nothing** — JS
+  /// pushes the clear envelope on sign-out, so "nothing" is just another
+  /// desired context and needs no special case here (#44 §6).
+  private var desired: [String: Any]?
+
+  private override init() { super.init() }
+
+  var isSupported: Bool { WCSession.isSupported() }
+
+  private var activatedSession: WCSession? {
+    guard WCSession.isSupported() else { return nil }
+    let session = WCSession.default
+    guard session.activationState == .activated else { return nil }
+    return session
+  }
+
+  var isPaired: Bool { activatedSession?.isPaired ?? false }
+  var isWatchAppInstalled: Bool { activatedSession?.isWatchAppInstalled ?? false }
+
+  func start() {
+    guard WCSession.isSupported() else { return }
+    let session = WCSession.default
+    session.delegate = self
+    session.activate()
+  }
+
+  /// Send `record` unless the counterpart already holds exactly it.
+  ///
+  /// Returns whether anything was handed to the system. `false` covers both
+  /// "no watch to send to" and "already in sync" — neither is an error, and
+  /// the caller treats them identically.
+  @discardableResult
+  func assert(_ record: [String: Any]) -> Bool {
+    desired = record
+    guard let session = activatedSession else { return false }
+
+    // `updateApplicationContext` is latest-wins and never queues, so a
+    // redundant send costs nothing on the phone — but it does spend a
+    // background wake on the watch, and a wake's `reloadTimelines` counts
+    // against the 40–75/day reload budget. Skipping the no-op keeps the steady
+    // state free (#39 §4).
+    if sameContext(session.applicationContext, record) { return false }
+
+    do {
+      try session.updateApplicationContext(record)
+      return true
+    } catch {
+      // `deviceNotPaired` / `watchAppNotInstalled` are the ordinary case, not
+      // a fault. Anything else is equally unactionable from JS: there is no
+      // retry that would help, and the next `assert` re-sends anyway.
+      return false
+    }
+  }
+
+  /// Equality over the one-key string envelope this transport carries. Kept
+  /// deliberately narrow — a general `NSDictionary` compare would invite
+  /// richer payloads, and the whole point of the envelope is that there is
+  /// only ever one string in it (#38 §3).
+  private func sameContext(_ a: [String: Any], _ b: [String: Any]) -> Bool {
+    guard a.count == b.count else { return false }
+    for (key, value) in b {
+      guard let lhs = a[key] as? String, let rhs = value as? String, lhs == rhs else {
+        return false
+      }
+    }
+    return true
+  }
+
+  private func reassert() {
+    guard let desired else { return }
+    _ = assert(desired)
+  }
+
+  // MARK: WCSessionDelegate
+  //
+  // No phone-side events reach JS. The phone never listens; the watch does
+  // (#37 §3). These callbacks exist only to re-assert.
+
+  func session(
+    _ session: WCSession,
+    activationDidCompleteWith activationState: WCSessionActivationState,
+    error: Error?
+  ) {
+    guard error == nil, activationState == .activated else { return }
+    reassert()
+  }
+
+  /// Fires on exactly the pairing and installation transitions that strand a
+  /// context in the daemon.
+  func sessionWatchStateDidChange(_ session: WCSession) {
+    reassert()
+  }
+
+  // Required on iOS. Switching to a second watch deactivates the session and
+  // hands us a new one; re-activating and re-asserting is what keeps the new
+  // wrist in step.
+  func sessionDidBecomeInactive(_ session: WCSession) {}
+
+  func sessionDidDeactivate(_ session: WCSession) {
+    session.activate()
+  }
+}
+
+public class WatchLinkModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("WatchLink")
+
+    OnCreate {
+      WatchLinkSession.shared.start()
+    }
+
+    Property("isSupported") { WatchLinkSession.shared.isSupported }
+    Property("isPaired") { WatchLinkSession.shared.isPaired }
+    Property("isWatchAppInstalled") { WatchLinkSession.shared.isWatchAppInstalled }
+
+    /// The single verb. `record` is the envelope JS built; this module does not
+    /// know or care what is inside it.
+    Function("updateApplicationContext") { (record: [String: Any]) -> Bool in
+      WatchLinkSession.shared.assert(record)
+    }
+  }
+}

--- a/apps/mobile/src/lib/widget.ts
+++ b/apps/mobile/src/lib/widget.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Constants, { ExecutionEnvironment } from 'expo-constants';
 import { Platform } from 'react-native';
+import { updateApplicationContext } from '../../modules/watch-link';
 import {
   WIDGET_SNAPSHOT_KEY,
   type DailyTargets,
@@ -43,6 +44,25 @@ export const APP_GROUP = 'group.fit.ignia.app';
  *  the SwiftUI widget declares. The reload calls address the widget by it. */
 export const WIDGET_NAME = 'Today';
 
+/**
+ * The only key inside the WatchConnectivity application-context envelope. Must
+ * equal `Glance.contextKey` in `targets/_shared/Glance.swift`.
+ *
+ * The value is the **already-serialized snapshot JSON**, byte-identical to what
+ * `ExtensionStorage` writes into the App Group. Sending the eight fields as a
+ * native dictionary instead would have created a second decode path in Swift
+ * (dict→Snapshot alongside JSON→Snapshot) and made the dictionary's key set a
+ * third thing to keep in step with the TS interface — the exact drift the
+ * shared contract exists to prevent. With the envelope, the watch delegate does
+ * `defaults.set(json, forKey:)` and nothing else, and the decoder count stays
+ * at one (#38 §3).
+ *
+ * It lives here rather than in `@macrolog/core` because it is transport
+ * plumbing, not domain: it never touches disk, never appears in a stored blob,
+ * and has no bearing on the wire version.
+ */
+export const WATCH_CONTEXT_KEY = 'snapshot';
+
 /** Expo Go has neither native module linked, and web has no home screen. */
 const supported =
   Constants.executionEnvironment !== ExecutionEnvironment.StoreClient &&
@@ -68,6 +88,13 @@ async function persist(snapshot: WidgetSnapshot): Promise<void> {
     // only refresh on its own (slow, OS-chosen) cadence and a just-logged meal
     // wouldn't show up until much later.
     ExtensionStorage.reloadWidget(WIDGET_NAME);
+    // Same bytes, one hop further out: the Apple Watch complication cannot read
+    // this App Group (App Groups are per-device), so the blob is asserted to
+    // the watch over WatchConnectivity. This rides the existing call site and
+    // the existing `widgetSnapshotChanged` guard on purpose — one trigger, one
+    // guard, both surfaces, no watch-specific notion of "changed" (#37 §5).
+    // Never throws; a watch-less iPhone is the ordinary case.
+    updateApplicationContext({ [WATCH_CONTEXT_KEY]: json });
     if (__DEV__) {
       // `UserDefaults(suiteName:)` returns nil when the process is not entitled
       // to the App Group, and the write then no-ops WITHOUT throwing. Reading
@@ -187,19 +214,59 @@ export async function readWidgetSnapshot(): Promise<WidgetSnapshot | null> {
 
 /**
  * Drop the blob and forget the in-process guard. Used on sign-out and account
- * deletion: the widget must not keep showing the previous account's numbers on
- * a home screen after the app no longer has a session.
+ * deletion: no glanceable surface may keep showing the previous account's
+ * numbers after the app no longer has a session.
+ *
+ * **This is the only clear path, and it does not go through `persist()`** — so
+ * the watch push here is not inherited from `syncWidget`, it has to be written
+ * out. It is also unconditional: `widgetSnapshotChanged` is consulted only by
+ * `syncWidget`, so the change guard can never swallow a clear (#44 §5).
+ *
+ * `auth.tsx` awaits this **before** `fbSignOut(auth)`, and that ordering is
+ * load-bearing rather than incidental: `runDeleteAccount` deliberately swallows
+ * `signOut()` failures ("the Auth user is already gone"), so a clear placed
+ * after the Firebase sign-out would be skipped on exactly the fragile path
+ * (#44 §4). Do not reorder it.
+ *
+ * On the watch, the honest bound is: **cleared on next contact, or at the
+ * watch's local midnight, whichever comes first.** Application context cannot
+ * be dropped in transit — it sits with the system daemon and is delivered on
+ * next contact — but it also cannot be delivered to a watch that is not there.
+ * The day-key guard in `Glance.swift` is the backstop, and it is a privacy
+ * mechanism as much as a freshness one. A watch-side self-clear was declined:
+ * it would infer "signed out" from silence, and silence has four innocent
+ * causes (#44 §3).
  */
 export async function clearWidget(): Promise<void> {
   lastWritten = null;
   if (!supported) return;
-  try {
-    if (Platform.OS === 'ios') {
+
+  if (Platform.OS === 'ios') {
+    // Two separate privacy obligations on two separate devices. They used to
+    // share one `try`; neither may be skipped because the other threw, which is
+    // the same reasoning `CLAUDE.md` already applies to the hourly dispatcher's
+    // `Promise.allSettled` (#44 §5.2).
+    try {
       const { ExtensionStorage } = require('@bacons/apple-targets');
       new ExtensionStorage(APP_GROUP).set(WIDGET_SNAPSHOT_KEY, undefined);
       ExtensionStorage.reloadWidget(WIDGET_NAME);
-      return;
+    } catch (err) {
+      if (__DEV__) console.warn('[widget] App Group clear FAILED', err);
     }
+
+    try {
+      // The empty string, inside the same one-key envelope. It fails the decode
+      // on the watch and collapses to the empty face exactly as an absent or
+      // unreadable blob does — no fourth empty reason, no new key, no second
+      // decode path. `Waiting for iPhone` is the face (#44 §2).
+      updateApplicationContext({ [WATCH_CONTEXT_KEY]: '' });
+    } catch (err) {
+      if (__DEV__) console.warn('[widget] watch clear FAILED', err);
+    }
+    return;
+  }
+
+  try {
     await AsyncStorage.removeItem(WIDGET_SNAPSHOT_KEY);
     const { requestWidgetUpdate } = require('react-native-android-widget');
     const { renderTodayWidget } = require('../widgets/render');
@@ -209,6 +276,8 @@ export async function clearWidget(): Promise<void> {
       widgetNotFound: () => {},
     });
   } catch {
-    // Best-effort; see syncWidget.
+    // Best-effort; see syncWidget. Android has no second-device half — the
+    // widget renders inside our own JS context, in the same process that owns
+    // the session, and storage is cleared before the redraw is requested (#44 §7).
   }
 }

--- a/apps/mobile/targets/_shared/Glance.swift
+++ b/apps/mobile/targets/_shared/Glance.swift
@@ -94,6 +94,20 @@ public enum Glance {
     public let proteinTarget: Int
     public let updatedMs: Double
     public let locale: String
+
+    public init(
+      v: Int, dateKey: String, kcalConsumed: Int, kcalTarget: Int,
+      proteinConsumed: Int, proteinTarget: Int, updatedMs: Double, locale: String
+    ) {
+      self.v = v
+      self.dateKey = dateKey
+      self.kcalConsumed = kcalConsumed
+      self.kcalTarget = kcalTarget
+      self.proteinConsumed = proteinConsumed
+      self.proteinTarget = proteinTarget
+      self.updatedMs = updatedMs
+      self.locale = locale
+    }
   }
 
   /// Mirrors `WidgetMetric`: distance from target, which side of it, and the
@@ -172,6 +186,29 @@ public enum Glance {
       protein: Metric(consumed: snap.proteinConsumed, target: snap.proteinTarget),
       snapshot: snap
     )
+  }
+
+  /// The face WidgetKit shows in the gallery and while a real entry loads.
+  ///
+  /// Plausible numbers rather than the empty state, so the gallery preview
+  /// sells what the surface does. Shared so the phone widget and the watch
+  /// complication cannot advertise different numbers, and built as a value
+  /// rather than a JSON string so a typo in a hand-written literal cannot
+  /// silently degrade the preview to `.empty`.
+  public static func preview(now: Date = Date()) -> Face {
+    let snap = Snapshot(
+      v: version,
+      dateKey: localDateKey(now),
+      kcalConsumed: 1240,
+      kcalTarget: 2000,
+      proteinConsumed: 92,
+      proteinTarget: 160,
+      updatedMs: now.timeIntervalSince1970 * 1000,
+      locale: "en")
+    return .ready(
+      kcal: Metric(consumed: snap.kcalConsumed, target: snap.kcalTarget),
+      protein: Metric(consumed: snap.proteinConsumed, target: snap.proteinTarget),
+      snapshot: snap)
   }
 
   /// Read the blob out of the App Group and decode it. Same call on the phone

--- a/apps/mobile/targets/_shared/Glance.swift
+++ b/apps/mobile/targets/_shared/Glance.swift
@@ -1,0 +1,331 @@
+import Foundation
+
+//
+//  Ignia — the one Swift mirror of `packages/core/src/widget-snapshot.ts`.
+//
+//  ## Why this file is here and not in each target
+//
+//  `@bacons/apple-targets@5.0.0` globs `targets/_shared/*` and attaches it to
+//  EVERY target in the project (`build/with-xcode-changes.js`, README §_shared).
+//  So this is the only directory that reaches the iPhone widget, the watch app
+//  and the watch complication at once. Per-target `targets/<name>/_shared/`
+//  would reach one target each and put us back at three copies (#38 §1).
+//
+//  The deletion test: remove this file and the staleness guard reappears in
+//  three Swift targets. A drifted guard does not fail loudly — it renders
+//  yesterday's calories as today's, the single most dangerous bug this feature
+//  has.
+//
+//  ## Two hard rules for anything added here
+//
+//  1. **Foundation only. No SwiftUI, no WidgetKit.** The shared group is linked
+//     into the MAIN APP target unconditionally, so everything here compiles
+//     against the phone app's iOS floor (16.4, `expo-build-properties` in
+//     app.json) *and* against watchOS 10. `Gauge` is iOS 16+, `.containerBackground`
+//     is iOS 17+; shared SwiftUI would need `@available` guards on code that can
+//     only be compiled by spending an EAS build. Views are deliberately NOT
+//     shared (#38 §2).
+//
+//     The dividing line, stated once: **what can silently show wrong _numbers_
+//     is shared; what can only look wrong is not.**
+//
+//  2. **Namespaced under `Glance`.** These symbols land in the main app module
+//     too, so bare top-level names like `Snapshot` or `strings` would be a
+//     collision waiting to happen.
+//
+//  Prebuild must be re-run on any add/rename/remove in this directory — the
+//  glob runs at prebuild time and is non-recursive (one level).
+//
+//  Spec: `packages/core/src/widget-snapshot.ts`; its vitest suite is the
+//  reference for every rule below. When one side changes, change both.
+//
+
+public enum Glance {
+
+  // MARK: - Contract constants
+  //
+  // Under `_shared` these stop being the prose "Must equal …" contracts the
+  // per-target copies used to carry and become actual shared constants
+  // compiled into every Apple target (#38 §1).
+
+  /// Must equal `WIDGET_SNAPSHOT_KEY` in `packages/core/src/widget-snapshot.ts`.
+  ///
+  /// The watch stores under this same key in **its own** App Group container.
+  /// No collision — App Groups are per-device, which is the whole reason the
+  /// WCSession transport exists (#32).
+  public static let snapshotKey = "ignia.widget.snapshot.v1"
+
+  /// Must equal `APP_GROUP` in `src/lib/widget.ts` and the entitlement in
+  /// app.json. On the watch this names the watch app ↔ complication container.
+  public static let appGroup = "group.fit.ignia.app"
+
+  /// Must equal `WIDGET_SNAPSHOT_VERSION`. A blob written by a newer app is
+  /// rejected rather than partially decoded — during an app update the widget
+  /// extension keeps running old code until the OS reloads it. An old watch
+  /// binary receiving a v2 blob stores it, fails this gate at render, and shows
+  /// the empty face — identical to the phone widget's behaviour (#38 §3).
+  public static let version = 1
+
+  /// The `kind` the iPhone widget declares and `ExtensionStorage.reloadWidget`
+  /// addresses. Must equal `WIDGET_NAME` in `src/lib/widget.ts`.
+  public static let widgetKind = "Today"
+
+  /// The watch complication's `kind`. Only the watch app reloads it, and it
+  /// does so via `reloadAllTimelines`, so this is not a cross-process contract
+  /// the way `widgetKind` is — it is here so the two watch targets agree.
+  public static let complicationKind = "IgniaGlance"
+
+  /// The single key inside the WCSession application-context envelope. The
+  /// value is the already-serialized snapshot JSON — byte-identical to what
+  /// `ExtensionStorage` writes phone-side — so there is no second wire format
+  /// and no second decode path in Swift (#38 §3).
+  public static let contextKey = "snapshot"
+
+  // MARK: - Wire shape
+
+  /// Mirrors `WidgetSnapshot`. Every field is a primitive and every number is a
+  /// rounded integer, so JS and Swift cannot disagree about formatting.
+  public struct Snapshot: Codable {
+    public let v: Int
+    public let dateKey: String
+    public let kcalConsumed: Int
+    public let kcalTarget: Int
+    public let proteinConsumed: Int
+    public let proteinTarget: Int
+    public let updatedMs: Double
+    public let locale: String
+  }
+
+  /// Mirrors `WidgetMetric`: distance from target, which side of it, and the
+  /// clamped ratio.
+  ///
+  /// `progress` is a **derived view field, not a wire field** — it is computed
+  /// here and never stored (#38 §5, which is why no version bump was needed).
+  /// It is clamped to `0...1`, so a gauge cannot overshoot: at 140% of target
+  /// the ring looks identical to 100%. That clamp is what forces the
+  /// over-target text treatment (#33).
+  public struct Metric {
+    public let value: Int
+    public let isOver: Bool
+    public let progress: Double
+
+    public init(consumed: Int, target: Int) {
+      isOver = consumed > target
+      value = abs(target - consumed)
+      progress = target > 0 ? min(1, max(0, Double(consumed) / Double(target))) : 0
+    }
+  }
+
+  /// Mirrors `WidgetView`, named `Face` so it cannot collide with SwiftUI's
+  /// `View` in the targets that import SwiftUI.
+  ///
+  /// The three `WidgetEmptyReason`s are collapsed into one case because every
+  /// Apple surface renders them identically and the user cannot act on the
+  /// difference. The TS side keeps them apart only so its tests can tell an app
+  /// that has never run from one that hasn't been opened today.
+  ///
+  /// `locale` is `nil` **only** for `no-snapshot` — nothing on disk means there
+  /// is no stored preference to honour, the one case where falling back to
+  /// English is the only option. For `stale` and `no-targets` the blob exists
+  /// and names the user's locale, so an es-PR Lock Screen no longer flips to
+  /// English at midnight (#33).
+  public enum Face {
+    case empty(locale: String?)
+    case ready(kcal: Metric, protein: Metric, snapshot: Snapshot)
+
+    /// The locale to render this face in, resolved. Used when a timeline has to
+    /// carry today's locale into a *future* entry (the post-midnight blank).
+    public var locale: String {
+      switch self {
+      case let .empty(l): return l ?? "en"
+      case let .ready(_, _, snap): return snap.locale
+      }
+    }
+  }
+
+  // MARK: - Decode + the staleness guard
+  //
+  // This guard is the reason the file exists. It also does privacy work nobody
+  // originally noticed: after a sign-out whose watch clear never landed, the
+  // day-key rule is what blanks the previous account's numbers at the rendering
+  // device's local midnight (#44).
+
+  /// Mirrors `parseWidgetSnapshot` + `widgetView`. Anything unreadable, foreign
+  /// versioned, from another day, or without a calorie target collapses to
+  /// `.empty` — **never a thrown error**, which would show the OS's "unable to
+  /// load" placeholder and read as a crashed app.
+  public static func face(raw: String?, now: Date) -> Face {
+    guard
+      let raw,
+      let data = raw.data(using: .utf8),
+      let snap = try? JSONDecoder().decode(Snapshot.self, from: data),
+      snap.v == version
+    else {
+      return .empty(locale: nil)
+    }
+
+    guard snap.dateKey == localDateKey(now) else { return .empty(locale: snap.locale) }
+    guard snap.kcalTarget > 0 else { return .empty(locale: snap.locale) }
+
+    return .ready(
+      kcal: Metric(consumed: snap.kcalConsumed, target: snap.kcalTarget),
+      protein: Metric(consumed: snap.proteinConsumed, target: snap.proteinTarget),
+      snapshot: snap
+    )
+  }
+
+  /// Read the blob out of the App Group and decode it. Same call on the phone
+  /// (written by `ExtensionStorage`) and on the watch (written by the watch
+  /// app's `WCSessionDelegate`) — the container differs, the code does not.
+  ///
+  /// `UserDefaults(suiteName:)` returns nil when the process is not entitled to
+  /// the group, which is a silent failure mode; it collapses to `.empty` here
+  /// exactly like an absent blob.
+  public static func load(now: Date) -> Face {
+    let raw = UserDefaults(suiteName: appGroup)?.string(forKey: snapshotKey)
+    return face(raw: raw, now: now)
+  }
+
+  /// Mirrors `localDateKey` from `packages/core/src/date.ts`: `YYYY-MM-DD` in
+  /// the device's *local* zone. Must not be UTC — the whole point of the date
+  /// key is that it flips at the user's midnight, not at Greenwich's.
+  public static func localDateKey(_ date: Date) -> String {
+    let f = DateFormatter()
+    f.calendar = Calendar(identifier: .gregorian)
+    f.locale = Locale(identifier: "en_US_POSIX")
+    f.dateFormat = "yyyy-MM-dd"
+    return f.string(from: date)
+  }
+
+  // MARK: - Strings
+  //
+  // One flat table, EVERY key present, keyed by locale only (#38 §4). The watch
+  // introduced a new axis the phone never had — the same locale needs different
+  // empty copy per surface — and that axis is absorbed by key names, not by a
+  // second lookup dimension. Each target reads only the keys it renders; the
+  // cost is a few dozen bytes of another surface's copy per binary, the benefit
+  // is one place to check en/es-PR parity.
+  //
+  // Not a String Catalog: our locale comes from the BLOB, not the system, and
+  // forcing a non-system locale means the `lproj` bundle dance (see
+  // `src/widgets/strings.ts:1-11`).
+  //
+  // The Android widget keeps its own table in `src/widgets/strings.ts` — it
+  // runs in JS and cannot read this. Two tables total, not three.
+
+  public struct Strings {
+    /// Unit word. Same in both locales; kept as a key so a third locale can
+    /// change it.
+    public let kcal: String
+    /// Under target. `1,240 kcal **left**`
+    public let left: String
+    /// Over target. `1,240 kcal **over**`
+    public let over: String
+    public let protein: String
+    /// Phone Lock Screen / Home Screen empty state — an instruction, because on
+    /// a phone the instruction works: tap, the app writes, the widget heals.
+    public let empty: String
+    /// Same instruction for families with no room (`.accessoryInline`).
+    public let emptyShort: String
+    /// Watch empty state. Deliberately NOT "Open Ignia" — a complication tap
+    /// opens the read-only mirror, which has the same nothing on it, because
+    /// the watch has no pull path. Telling someone to open an app that cannot
+    /// help them is a dead end, not a nag (#40 §4).
+    ///
+    /// A status, not an instruction, so it cannot nag; and it states a fact
+    /// about the *watch's own knowledge* rather than a claim about the phone.
+    /// It also reads correctly at 00:05 after a night apart — the single most
+    /// common way a watch reaches this state.
+    public let emptyWatch: String
+    /// The whole feature's explanatory copy, shown once, on the watch screen's
+    /// empty state — exactly where a confused user arrives from the face
+    /// (#40 §5). There is no settings line and no onboarding moment.
+    public let watchSubline: String
+    /// Format for the honesty row. `%@` is a locale-formatted time.
+    public let asOf: String
+    /// Watch mirror screen only: the label under the hero number.
+    public let kcalLeftLabel: String
+    /// Watch mirror screen only: the label under the hero number, over target.
+    public let kcalOverLabel: String
+  }
+
+  /// Keyed by the locale carried in the snapshot — our locale is a *profile*
+  /// preference stored in Firestore, so the device locale would be wrong for
+  /// anyone whose app language differs from their phone's. System locale is the
+  /// fallback only when no blob has ever arrived, which is what `.empty(nil)`
+  /// resolving to `"en"` expresses.
+  public static func strings(_ locale: String) -> Strings {
+    switch locale {
+    case "es-PR":
+      return Strings(
+        kcal: "kcal",
+        left: "restantes",
+        over: "de más",
+        protein: "proteína",
+        empty: "Abre Ignia para empezar",
+        emptyShort: "Abre Ignia",
+        emptyWatch: "Esperando al iPhone",
+        watchSubline: "Tus números se actualizan cuando tu iPhone está cerca.",
+        asOf: "a las %@",
+        kcalLeftLabel: "kcal restantes",
+        kcalOverLabel: "kcal de más"
+      )
+    default:
+      return Strings(
+        kcal: "kcal",
+        left: "left",
+        over: "over",
+        protein: "protein",
+        empty: "Open Ignia to start",
+        emptyShort: "Open Ignia",
+        emptyWatch: "Waiting for iPhone",
+        watchSubline: "Your numbers update when your iPhone is nearby.",
+        asOf: "as of %@",
+        kcalLeftLabel: "kcal left",
+        kcalOverLabel: "kcal over"
+      )
+    }
+  }
+
+  // MARK: - Formatting
+
+  /// Digit grouping. Hardcodes `,` rather than following the blob's locale,
+  /// because this is the formatter the shipped-and-device-verified iPhone
+  /// widget already uses — one implementation across all surfaces is worth more
+  /// here than per-locale separators, and switching would silently change a
+  /// face that is live on the App Store.
+  public static func grouped(_ n: Int) -> String {
+    let f = NumberFormatter()
+    f.numberStyle = .decimal
+    f.groupingSeparator = ","
+    return f.string(from: NSNumber(value: n)) ?? String(n)
+  }
+
+  /// `1,240 kcal left` / `1,240 kcal de más`.
+  public static func kcalLine(_ m: Metric, _ s: Strings) -> String {
+    "\(grouped(m.value)) \(s.kcal) \(m.isOver ? s.over : s.left)"
+  }
+
+  /// `68g protein left` / `68g de proteína restantes`.
+  ///
+  /// The es-PR string runs ~40% longer than the English one, which is why every
+  /// layout carrying it is designed against es-PR rather than en (#43).
+  public static func proteinLine(_ m: Metric, _ s: Strings) -> String {
+    "\(grouped(m.value))g \(s.protein) \(m.isOver ? s.over : s.left)"
+  }
+
+  /// `as of 8:04 AM` / `a las 8:04`.
+  ///
+  /// Time goes through the OS for the **blob's** locale, so 12h/24h follows the
+  /// user's own settings and nothing is hand-rolled. "as of" is not optional:
+  /// a bare `8:04 AM` on a watch face sits inches from the actual clock reading
+  /// 1:47 PM and reads as a second timepiece (#40 §2).
+  public static func asOfLine(updatedMs: Double, locale: String) -> String {
+    let f = DateFormatter()
+    f.locale = Locale(identifier: locale)
+    f.timeStyle = .short
+    f.dateStyle = .none
+    let time = f.string(from: Date(timeIntervalSince1970: updatedMs / 1000))
+    return String(format: strings(locale).asOf, time)
+  }
+}

--- a/apps/mobile/targets/watch-widget/expo-target.config.js
+++ b/apps/mobile/targets/watch-widget/expo-target.config.js
@@ -1,0 +1,32 @@
+/**
+ * Watch face complication target. See the sibling
+ * `targets/watch/expo-target.config.js` header for the `deploymentTarget: 10.0`
+ * reasoning — it is pinned on both, explicitly, so they cannot drift.
+ *
+ * The App Group entitlement is declared EXPLICITLY here, and that is a finding,
+ * not boilerplate. `watch-widget` is flagged `appGroupsByDefault: true` in the
+ * plugin's target table, so #32 predicted it would mirror `group.fit.ignia.app`
+ * from `app.json` unaided — the way `targets/widget` relies on. A first prebuild
+ * run with this block omitted emitted the target with **no
+ * `CODE_SIGN_ENTITLEMENTS` at all** (#45), so the complication could not have
+ * opened the container the watch app writes into, and the face would have sat
+ * on its empty state forever with nothing to point at. Do not "simplify" it
+ * back out.
+ *
+ * Note the App Group here is the *watch's own* container. It shares with the
+ * watch app on the watch and never with the phone — which is the entire reason
+ * a transport exists at all.
+ *
+ * @type {import('@bacons/apple-targets/app.plugin').ConfigFunction}
+ */
+module.exports = (config) => ({
+  type: 'watch-widget',
+  name: 'IgniaWatchComplication',
+  bundleIdentifier: '.watchkitapp.complication',
+  deploymentTarget: '10.0',
+  frameworks: ['WidgetKit', 'SwiftUI'],
+  entitlements: {
+    'com.apple.security.application-groups':
+      config.ios.entitlements['com.apple.security.application-groups'],
+  },
+});

--- a/apps/mobile/targets/watch-widget/index.swift
+++ b/apps/mobile/targets/watch-widget/index.swift
@@ -1,0 +1,223 @@
+import SwiftUI
+import WidgetKit
+
+//
+//  Ignia — Apple Watch face complication.
+//
+//  Reads the watch's own App Group, which the watch app writes on every
+//  WatchConnectivity delivery (`targets/watch/index.swift`). This process never
+//  talks to the phone, the network, or Firestore — same snapshot-not-subscribe
+//  contract as the iPhone widget, one hop further out.
+//
+//  Families: circular, rectangular, inline — mirroring the Lock Screen exactly
+//  (#40 §0). `.accessoryCorner` is deliberately absent; it is the only family
+//  with no Lock Screen counterpart, so it would be the only net-new layout.
+//
+//  ## The one thing this face says that the phone's does not
+//
+//  An unconditional `as of 8:04 AM` on rectangular. On the phone that row would
+//  imply a doubt that does not exist; here the number really can be an hour
+//  old, or older while the two devices are apart. Circular and inline stay bare
+//  **by decision, not by omission** — one tap reaches the watch app, which
+//  always shows the honest answer (#40 §2, #39 §6). Do not "fix" that later.
+//
+//  ## Why there is no staleness *mark*
+//
+//  It would have been free — the reload budget meters `getTimeline` calls, not
+//  entries within a timeline — and it is still wrong. `updatedMs` is the age of
+//  the last **log**, not the age of the last **contact**, so it cannot tell
+//  "logged lunch, watch never received it" from "simply hasn't eaten since
+//  breakfast". The second is the common case, and an ordinary day has 4½- and
+//  6½-hour gaps, so the mark would be lit through most of waking hours. A
+//  timestamp asserts nothing, so it has no false-positive class (#40 §1).
+//
+
+private struct Entry: TimelineEntry {
+  let date: Date
+  let face: Glance.Face
+}
+
+private struct Provider: TimelineProvider {
+  func placeholder(in context: Context) -> Entry {
+    Entry(
+      date: Date(),
+      face: Glance.face(
+        raw: """
+          {"v":1,"dateKey":"\(Glance.localDateKey(Date()))","kcalConsumed":1240,\
+          "kcalTarget":2000,"proteinConsumed":92,"proteinTarget":160,\
+          "updatedMs":\(Date().timeIntervalSince1970 * 1000),"locale":"en"}
+          """,
+        now: Date()))
+  }
+
+  func getSnapshot(in context: Context, completion: @escaping (Entry) -> Void) {
+    completion(Entry(date: Date(), face: Glance.load(now: Date())))
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
+    let now = Date()
+    let current = Glance.load(now: now)
+    var entries = [Entry(date: now, face: current)]
+
+    // The midnight backstop, same as the phone widget's. On the wrist it does
+    // more than freshness: it is the privacy bound on a sign-out whose clear
+    // never reached this device. "Cleared on next contact, or at the watch's
+    // local midnight, whichever comes first" (#44 §3).
+    let cal = Calendar.current
+    if let midnight = cal.nextDate(
+      after: now, matching: DateComponents(hour: 0, minute: 0, second: 5),
+      matchingPolicy: .nextTime)
+    {
+      entries.append(Entry(date: midnight, face: .empty(locale: current.locale)))
+    }
+
+    completion(Timeline(entries: entries, policy: .atEnd))
+  }
+}
+
+// MARK: - Families
+//
+// `.primary` / `.secondary` and `.tint(.primary)` only — no brand colour, for
+// the same reason as the Lock Screen: hierarchy is carried by weight and size.
+
+private struct CircularView: SwiftUI.View {
+  let face: Glance.Face
+
+  var body: some SwiftUI.View {
+    switch face {
+    case .empty:
+      // Wordless, and the slot never changes shape between states — which
+      // matters most at midnight, the one transition we would rather not draw
+      // the eye to.
+      Gauge(value: 0.0) {
+        Image(systemName: "flame")
+      }
+      .gaugeStyle(.accessoryCircularCapacity)
+
+    case let .ready(kcal, _, _):
+      Gauge(value: kcal.progress) {
+        Text(kcal.isOver ? "+" : "")
+      } currentValueLabel: {
+        // `progress` is clamped to 0...1, so at 140% of target the ring looks
+        // identical to 100%. The `+` is what distinguishes them, and it needs
+        // no es-PR translation.
+        Text(kcal.isOver ? "+\(Glance.grouped(kcal.value))" : Glance.grouped(kcal.value))
+          .minimumScaleFactor(0.5)
+          .lineLimit(1)
+      }
+      .gaugeStyle(.accessoryCircularCapacity)
+    }
+  }
+}
+
+private struct RectangularView: SwiftUI.View {
+  let face: Glance.Face
+
+  var body: some SwiftUI.View {
+    switch face {
+    case let .empty(locale):
+      Label(Glance.strings(locale ?? "en").emptyWatch, systemImage: "flame")
+        .font(.headline)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+
+    case let .ready(kcal, protein, snap):
+      let s = Glance.strings(snap.locale)
+
+      // The smallest supported screen is 40mm `324 x 394`; the owner wears a
+      // 46mm `416 x 496`. Rather than measure once and hope, the layout
+      // degrades predictably: 4 rows where they fit, 3 where they do not. If
+      // the row has to go, it is `as of` that goes and never protein —
+      // rectangular is the only family carrying protein at all (#40, #43 §3).
+      //
+      // THREE DETAILS ARE LOAD-BEARING HERE. In descending order of how
+      // expensive they are to get wrong:
+      //
+      // (a) `.lineLimit(1)` is a CORRECTNESS PREREQUISITE, not a preference.
+      //     `ViewThatFits` measures a child's *ideal* size, and a `Text`'s
+      //     ideal height is one line no matter how long the string is. Without
+      //     an explicit line limit the 4-row candidate reports "fits", is
+      //     selected, and then wraps at render — clipping. The measurement
+      //     would lie in exactly the case this defends against, and hardest in
+      //     es-PR. Removing it to "let the Spanish string breathe" silently
+      //     re-arms the bug.
+      //
+      // (b) `in: .vertical`, not the default. The default constrains both axes,
+      //     so es-PR's ~40%-longer `68g de proteína restantes` could fail the
+      //     HORIZONTAL check and drop the honesty row on a 46mm watch with
+      //     ample vertical room. Width is handled by scaling; this branch is
+      //     about row count only.
+      //
+      // (c) The two candidates must differ ONLY by row count. Anything that
+      //     reduces the first candidate's ideal height — a smaller font on the
+      //     4-row variant, a `fixedSize`, a frame cap — makes `ViewThatFits`
+      //     always pick it and the fallback never fires. (`.minimumScaleFactor`
+      //     does not alter ideal size, so it is safe.)
+      ViewThatFits(in: .vertical) {
+        VStack(alignment: .leading, spacing: 1) {  // 46mm lands here
+          Text(Glance.kcalLine(kcal, s)).lineLimit(1).minimumScaleFactor(0.7)
+          Gauge(value: kcal.progress) { EmptyView() }
+            .gaugeStyle(.accessoryLinearCapacity)
+            .tint(.primary)
+          Text(Glance.proteinLine(protein, s))
+            .lineLimit(1).minimumScaleFactor(0.7)
+          Text(Glance.asOfLine(updatedMs: snap.updatedMs, locale: snap.locale))
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .lineLimit(1).minimumScaleFactor(0.7)
+        }
+        VStack(alignment: .leading, spacing: 1) {  // 40mm falls here
+          Text(Glance.kcalLine(kcal, s)).lineLimit(1).minimumScaleFactor(0.7)
+          Gauge(value: kcal.progress) { EmptyView() }
+            .gaugeStyle(.accessoryLinearCapacity)
+            .tint(.primary)
+          Text(Glance.proteinLine(protein, s))
+            .lineLimit(1).minimumScaleFactor(0.7)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+}
+
+private struct InlineView: SwiftUI.View {
+  let face: Glance.Face
+
+  var body: some SwiftUI.View {
+    switch face {
+    case let .empty(locale):
+      Label(Glance.strings(locale ?? "en").emptyWatch, systemImage: "flame")
+    case let .ready(kcal, _, snap):
+      Label(Glance.kcalLine(kcal, Glance.strings(snap.locale)), systemImage: "flame")
+    }
+  }
+}
+
+private struct ComplicationView: SwiftUI.View {
+  @Environment(\.widgetFamily) private var family
+  let entry: Entry
+
+  var body: some SwiftUI.View {
+    switch family {
+    case .accessoryRectangular: RectangularView(face: entry.face)
+    case .accessoryInline: InlineView(face: entry.face)
+    default: CircularView(face: entry.face)
+    }
+  }
+}
+
+@main
+struct IgniaComplication: Widget {
+  let kind = Glance.complicationKind
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: Provider()) { entry in
+      ComplicationView(entry: entry)
+    }
+    .configurationDisplayName("Ignia")
+    .description("Calories and protein left today.")
+    // No `widgetURL`. The watch app is one screen with no navigation, so there
+    // is nothing to deep-link to — a tap opens it, which is the default (#39 §8).
+    .supportedFamilies([.accessoryCircular, .accessoryRectangular, .accessoryInline])
+  }
+}

--- a/apps/mobile/targets/watch-widget/index.swift
+++ b/apps/mobile/targets/watch-widget/index.swift
@@ -39,15 +39,7 @@ private struct Entry: TimelineEntry {
 
 private struct Provider: TimelineProvider {
   func placeholder(in context: Context) -> Entry {
-    Entry(
-      date: Date(),
-      face: Glance.face(
-        raw: """
-          {"v":1,"dateKey":"\(Glance.localDateKey(Date()))","kcalConsumed":1240,\
-          "kcalTarget":2000,"proteinConsumed":92,"proteinTarget":160,\
-          "updatedMs":\(Date().timeIntervalSince1970 * 1000),"locale":"en"}
-          """,
-        now: Date()))
+    Entry(date: Date(), face: Glance.preview())
   }
 
   func getSnapshot(in context: Context, completion: @escaping (Entry) -> Void) {
@@ -95,8 +87,9 @@ private struct CircularView: SwiftUI.View {
       .gaugeStyle(.accessoryCircularCapacity)
 
     case let .ready(kcal, _, _):
+      // Wordless — no unit, no label, only the centred number.
       Gauge(value: kcal.progress) {
-        Text(kcal.isOver ? "+" : "")
+        EmptyView()
       } currentValueLabel: {
         // `progress` is clamped to 0...1, so at 140% of target the ring looks
         // identical to 100%. The `+` is what distinguishes them, and it needs

--- a/apps/mobile/targets/watch/expo-target.config.js
+++ b/apps/mobile/targets/watch/expo-target.config.js
@@ -29,6 +29,18 @@ module.exports = (config) => ({
   name: 'IgniaWatch',
   bundleIdentifier: '.watchkitapp',
   deploymentTarget: '10.0',
+  // A watchOS APP needs its own icon — unlike a widget or a complication,
+  // which have none. It shows in the watch's app grid, in the Watch app on the
+  // phone, and on the App Store listing. Reusing the phone icon is the decided
+  // answer (#39 §8: display name "Ignia", icon from the existing iOS asset);
+  // no third piece of artwork.
+  //
+  // Source is the 1024² master. **Watch for alpha**: Apple rejects App Store
+  // icons with an alpha channel and this PNG is RGBA. Expo strips it for the
+  // main app icon during prebuild; whether the apple-targets path does the same
+  // is unverified, and an ITMS-90717 rejection is the way it would surface.
+  // Check the generated `Assets.xcassets` at the first Mac sitting.
+  icon: '../../assets/images/icon.png',
   // WidgetKit is here for `WidgetCenter.shared.reloadAllTimelines()` — the
   // watch app is what asks the complication to redraw after a delivery.
   frameworks: ['SwiftUI', 'WatchConnectivity', 'WidgetKit'],

--- a/apps/mobile/targets/watch/expo-target.config.js
+++ b/apps/mobile/targets/watch/expo-target.config.js
@@ -1,0 +1,39 @@
+/**
+ * watchOS app target, generated into the Xcode project by
+ * `@bacons/apple-targets` during prebuild. Nothing here is checked into
+ * `ios/` — that directory stays generated (the app is managed/CNG). Ejecting a
+ * live App Store app was never on the table (#32).
+ *
+ * This target is **link 2 of the transport**, not decoration: WatchConnectivity
+ * delivers to the watch app, never to a complication directly, so it owns the
+ * `WCSession` delegate, the background task, the App Group write and the
+ * `reloadTimelines` (#37, #39).
+ *
+ * `deploymentTarget` is the `10.0` pin from #37 — NOT the plugin's 9.4 default,
+ * and pinned explicitly on BOTH watch targets so the two can never drift and
+ * neither silently inherits a default that moves on a dependency bump.
+ * 9.4 looks free and is not: it forces `if #available(watchOS 10, *)` branches
+ * and sits below the line where the **Smart Stack** exists, which is where an
+ * Apple Watch widget is actually discovered today. 11.0 was declined — it buys
+ * Smart Stack *ranking* at the cost of Series 4/5/SE-1, and presence is what a
+ * first watch surface needs.
+ *
+ * The bundle id is a leading-dot override, so it is appended to the main app's
+ * id (`fit.ignia.app.watchkitapp`). Apple requires a companion watch app's id
+ * to be the phone app's id plus a dot.
+ *
+ * @type {import('@bacons/apple-targets/app.plugin').ConfigFunction}
+ */
+module.exports = (config) => ({
+  type: 'watch',
+  name: 'IgniaWatch',
+  bundleIdentifier: '.watchkitapp',
+  deploymentTarget: '10.0',
+  // WidgetKit is here for `WidgetCenter.shared.reloadAllTimelines()` — the
+  // watch app is what asks the complication to redraw after a delivery.
+  frameworks: ['SwiftUI', 'WatchConnectivity', 'WidgetKit'],
+  entitlements: {
+    'com.apple.security.application-groups':
+      config.ios.entitlements['com.apple.security.application-groups'],
+  },
+});

--- a/apps/mobile/targets/watch/index.swift
+++ b/apps/mobile/targets/watch/index.swift
@@ -22,7 +22,7 @@ import WidgetKit
 //
 //  ## The chain, end to end
 //
-//    phone: widget.ts persist() → WatchLink.updateApplicationContext(json)
+//    phone: widget.ts persist() → WatchReceiver.updateApplicationContext(json)
 //      → [system daemon, latest-wins, opportunistic delivery]
 //      → watch: session(_:didReceiveApplicationContext:)
 //      → UserDefaults(suiteName: Glance.appGroup).set(json, forKey:)
@@ -45,8 +45,8 @@ import WidgetKit
 
 /// Owns the `WCSession` on the watch side. Single instance, activated at app
 /// launch and never torn down.
-final class WatchLink: NSObject, ObservableObject, WCSessionDelegate {
-  static let shared = WatchLink()
+final class WatchReceiver: NSObject, ObservableObject, WCSessionDelegate {
+  static let shared = WatchReceiver()
 
   /// What to draw right now. Republished on every receipt and re-derived from
   /// the App Group whenever the screen appears, so the day-key guard is
@@ -130,7 +130,7 @@ private let igAccent = Color(
 // MARK: - The screen
 
 private struct MirrorView: SwiftUI.View {
-  @ObservedObject var link = WatchLink.shared
+  @ObservedObject var link = WatchReceiver.shared
   @Environment(\.scenePhase) private var scenePhase
 
   var body: some SwiftUI.View {
@@ -218,7 +218,7 @@ private struct MirrorView: SwiftUI.View {
 
 @main
 struct IgniaWatchApp: App {
-  init() { WatchLink.shared.start() }
+  init() { WatchReceiver.shared.start() }
 
   var body: some Scene {
     WindowGroup {
@@ -230,7 +230,7 @@ struct IgniaWatchApp: App {
     // budget — Apple's exemption list is exhaustive and background execution is
     // not on it (#37 §5).
     .backgroundTask(.watchConnectivity) {
-      WatchLink.shared.refresh()
+      WatchReceiver.shared.refresh()
     }
   }
 }

--- a/apps/mobile/targets/watch/index.swift
+++ b/apps/mobile/targets/watch/index.swift
@@ -1,0 +1,236 @@
+import SwiftUI
+import WatchConnectivity
+import WidgetKit
+
+//
+//  Ignia — watchOS app.
+//
+//  ## This app is link 2 of the transport, not decoration
+//
+//  #37 chose `WCSession.updateApplicationContext` as the sole transport, and
+//  WatchConnectivity delivers to the *watch app*, never to a complication
+//  directly. So this target has a job it must do whether or not anyone ever
+//  opens it: receive the context, write it into the watch's own App Group, and
+//  ask WidgetKit to reload. Everything the user can see here is additive to
+//  that (#39).
+//
+//  It is (c) in #39's taxonomy — a one-screen read-only mirror. Not (a), an
+//  empty shell, because a complication tap opens the containing app and "watch
+//  binary whose only screen is empty" is the minimum-functionality shape that
+//  has already cost this app two rejections. Not (b), a quick-log affordance,
+//  because that needs a watch→phone write path this design does not have.
+//
+//  ## The chain, end to end
+//
+//    phone: widget.ts persist() → WatchLink.updateApplicationContext(json)
+//      → [system daemon, latest-wins, opportunistic delivery]
+//      → watch: session(_:didReceiveApplicationContext:)
+//      → UserDefaults(suiteName: Glance.appGroup).set(json, forKey:)
+//      → WidgetCenter.shared.reloadAllTimelines()
+//      → complication re-renders from the App Group
+//
+//  ## What it honestly buys
+//
+//  Seconds-to-minutes after a log with the watch on the wrist and the phone in
+//  pocket; 15–60 minutes once the day's reloads throttle; **unbounded** while
+//  watch and phone are out of range. Apple promises no latency at all —
+//  delivery is explicitly "when the opportunity arises". This is a best-effort
+//  surface and cannot be made into a live number. That is why the screen below
+//  always shows `as of`, and why there is no refresh affordance: the transport
+//  is one-directional and the watch cannot request anything. A control that
+//  cannot work is worse than none (#39 §8).
+//
+
+// MARK: - Receiver
+
+/// Owns the `WCSession` on the watch side. Single instance, activated at app
+/// launch and never torn down.
+final class WatchLink: NSObject, ObservableObject, WCSessionDelegate {
+  static let shared = WatchLink()
+
+  /// What to draw right now. Republished on every receipt and re-derived from
+  /// the App Group whenever the screen appears, so the day-key guard is
+  /// re-evaluated against the *current* clock rather than the one at receipt.
+  @Published var face: Glance.Face = .empty(locale: nil)
+
+  private override init() { super.init() }
+
+  func start() {
+    guard WCSession.isSupported() else {
+      // A watch app always has a counterpart, so this should be unreachable —
+      // but activating an unsupported session traps, so it is guarded anyway.
+      refresh()
+      return
+    }
+    let session = WCSession.default
+    session.delegate = self
+    session.activate()
+
+    // Read what already arrived. Apple delivers the last known context shortly
+    // after activation, but a context that landed while this process was dead
+    // is sitting in `receivedApplicationContext` right now and the delegate
+    // callback may not fire again. One line, covers delivery that happened
+    // before the view appeared (#39 §4).
+    store(session.receivedApplicationContext)
+    refresh()
+  }
+
+  /// Re-derive the face from the App Group without waiting for a delivery.
+  /// Cheap, and the only thing that moves the screen across local midnight.
+  func refresh() {
+    let next = Glance.load(now: Date())
+    DispatchQueue.main.async { self.face = next }
+  }
+
+  /// Store whatever arrived and reload. **No validation here, by design.**
+  ///
+  /// The `dateKey`/staleness guard lives only at render (`Glance.face`), for
+  /// two reasons: one guard implementation means the screen and the face can
+  /// never disagree about what "stale" means, and on a transient two-clock
+  /// disagreement a validating delegate would discard the only copy of data it
+  /// has **no way to re-request** — there is no pull on this transport
+  /// (#39 §5).
+  private func store(_ context: [String: Any]) {
+    guard let json = context[Glance.contextKey] as? String else { return }
+    UserDefaults(suiteName: Glance.appGroup)?.set(json, forKey: Glance.snapshotKey)
+    // A sign-out sends the empty string. It fails the decode and collapses to
+    // `.empty` exactly as an absent or unreadable blob does — no fourth reason,
+    // no new key, no second decode path (#44 §2).
+    refresh()
+    WidgetCenter.shared.reloadAllTimelines()
+  }
+
+  // MARK: WCSessionDelegate
+
+  func session(
+    _ session: WCSession,
+    activationDidCompleteWith activationState: WCSessionActivationState,
+    error: Error?
+  ) {
+    guard error == nil else { return }
+    store(session.receivedApplicationContext)
+  }
+
+  func session(_ session: WCSession, didReceiveApplicationContext context: [String: Any]) {
+    store(context)
+  }
+}
+
+// MARK: - Palette
+//
+// watchOS has no light mode, so there is no theme branch and no Swift port of
+// ADR-0014 here. Text is `.primary`/`.secondary` exactly like the complication;
+// a single accent tints the gauge so the App Store watch screenshot is not
+// unbranded. It is a CONSTANT, not a palette — do not grow it into a colour set
+// (#39 §3).
+
+private let igAccent = Color(
+  .sRGB, red: 0xff / 255, green: 0x6a / 255, blue: 0x3d / 255, opacity: 1)  // theme.ts `ring`
+
+// MARK: - The screen
+
+private struct MirrorView: SwiftUI.View {
+  @ObservedObject var link = WatchLink.shared
+  @Environment(\.scenePhase) private var scenePhase
+
+  var body: some SwiftUI.View {
+    // `ScrollView` rather than a fitted layout: this screen has more content
+    // than the complication and the 40mm class (324 x 394) is ~22% narrower
+    // than the 46mm the owner wears. Scrolling means nothing is ever cut, at
+    // any size, in any locale (#43 §5).
+    ScrollView {
+      VStack(spacing: 2) {
+        switch link.face {
+        case let .empty(locale):
+          let s = Glance.strings(locale ?? "en")
+          Text(s.emptyWatch)
+            .font(.headline)
+            .multilineTextAlignment(.center)
+          // The entire feature's explanatory copy, and it lives here because
+          // this screen is the tap target from the face — exactly where a
+          // confused user arrives. There is no settings line and no onboarding
+          // moment; both were declined (#40 §5).
+          Text(s.watchSubline)
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .multilineTextAlignment(.center)
+            .padding(.top, 4)
+
+        case let .ready(kcal, protein, snap):
+          let s = Glance.strings(snap.locale)
+
+          // Hero. If `as of` is not visible without scrolling on 40mm, the
+          // pre-decided fix is 44 → 36 — decided here so a Mac sitting produces
+          // a boolean rather than new design work (#43 §5).
+          Text(Glance.grouped(kcal.value))
+            .font(.system(size: 44, weight: .bold, design: .rounded))
+            .minimumScaleFactor(0.5)
+            .lineLimit(1)
+          Text(kcal.isOver ? s.kcalOverLabel : s.kcalLeftLabel)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+
+          Gauge(value: kcal.progress) { EmptyView() }
+            .gaugeStyle(.accessoryLinearCapacity)
+            .tint(igAccent)
+            .padding(.vertical, 4)
+
+          // The denominators are this screen's whole reason to exist — the
+          // face has no room for them (#39 §2). Both are read straight off the
+          // snapshot; no new fields were added for the watch.
+          Text("\(Glance.grouped(snap.kcalConsumed)) / \(Glance.grouped(snap.kcalTarget))")
+            .font(.footnote)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+          Text(
+            "\(s.protein) \(Glance.grouped(snap.proteinConsumed))/"
+              + "\(Glance.grouped(snap.proteinTarget))"
+          )
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .minimumScaleFactor(0.7)
+
+          // Unconditional — no age threshold, no appear-past-N-minutes
+          // behaviour. This is the point of having a screen at all: it buys the
+          // face the right to stay terse (#39 §6).
+          Text(Glance.asOfLine(updatedMs: snap.updatedMs, locale: snap.locale))
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .padding(.top, 6)
+            .lineLimit(1)
+            .minimumScaleFactor(0.7)
+        }
+      }
+      .frame(maxWidth: .infinity)
+    }
+    // No pull-to-refresh and no "sync now" anywhere on this screen. Re-deriving
+    // the face from the App Group is not a refresh — it cannot fetch anything,
+    // it only re-runs the day-key guard against the current clock.
+    .onAppear { link.refresh() }
+    .onChange(of: scenePhase) { _, phase in
+      if phase == .active { link.refresh() }
+    }
+  }
+}
+
+@main
+struct IgniaWatchApp: App {
+  init() { WatchLink.shared.start() }
+
+  var body: some Scene {
+    WindowGroup {
+      MirrorView()
+    }
+    // Keeps the app alive long enough to write the App Group and request the
+    // reload when the system wakes it for a WatchConnectivity delivery. Note a
+    // background wake's `reloadTimelines` DOES count against the 40–75/day
+    // budget — Apple's exemption list is exhaustive and background execution is
+    // not on it (#37 §5).
+    .backgroundTask(.watchConnectivity) {
+      WatchLink.shared.refresh()
+    }
+  }
+}

--- a/apps/mobile/targets/widget/index.swift
+++ b/apps/mobile/targets/widget/index.swift
@@ -57,19 +57,8 @@ private struct Entry: TimelineEntry {
 }
 
 private struct Provider: TimelineProvider {
-  /// Shown in the widget gallery and while the real entry loads. Uses plausible
-  /// numbers rather than the empty state so the gallery preview sells what the
-  /// widget does.
   func placeholder(in context: Context) -> Entry {
-    Entry(
-      date: Date(),
-      face: Glance.face(
-        raw: """
-          {"v":1,"dateKey":"\(Glance.localDateKey(Date()))","kcalConsumed":1240,\
-          "kcalTarget":2000,"proteinConsumed":92,"proteinTarget":160,\
-          "updatedMs":\(Date().timeIntervalSince1970 * 1000),"locale":"en"}
-          """,
-        now: Date()))
+    Entry(date: Date(), face: Glance.preview())
   }
 
   func getSnapshot(in context: Context, completion: @escaping (Entry) -> Void) {
@@ -168,12 +157,12 @@ private struct CircularView: SwiftUI.View {
       .gaugeStyle(.accessoryCircularCapacity)
 
     case let .ready(kcal, _, _):
+      // Wordless — no unit, no label, only the centred number. There is no room
+      // for a word here, and with `progress` clamped to 0...1 the ring alone
+      // cannot say "past target", so the over-target state is carried by a
+      // single `+` glyph on the value itself. It needs no es-PR translation.
       Gauge(value: kcal.progress) {
-        // Wordless. There is no room for a unit here, and with `progress`
-        // clamped to 0...1 the ring alone cannot say "past target" — so the
-        // over-target state is carried by a single `+` glyph, which needs no
-        // es-PR translation.
-        Text(kcal.isOver ? "+" : "")
+        EmptyView()
       } currentValueLabel: {
         Text(kcal.isOver ? "+\(Glance.grouped(kcal.value))" : Glance.grouped(kcal.value))
           .minimumScaleFactor(0.5)

--- a/apps/mobile/targets/widget/index.swift
+++ b/apps/mobile/targets/widget/index.swift
@@ -2,137 +2,31 @@ import SwiftUI
 import WidgetKit
 
 //
-//  Ignia — "Today" home-screen widget (iOS).
+//  Ignia — "Today" widget (iOS): Home Screen `systemSmall` + the three Lock
+//  Screen accessory families.
 //
-//  This file is the Swift mirror of `packages/core/src/widget-snapshot.ts`.
-//  A WidgetKit extension is a separate process that cannot run our JS, so the
-//  decode + staleness + remaining rules are reimplemented here by hand. That
-//  TS module is the spec and its vitest suite is the reference for the
-//  behaviour below — when one side changes, change both.
+//  The decode, the staleness guard, the metrics, the string table and every
+//  contract constant now live in `targets/_shared/Glance.swift`, which the
+//  apple-targets plugin links into every target. This file is SwiftUI, a
+//  `TimelineProvider`, and `@main` — nothing else (#38 §1).
 //
-//  Data flow: the RN app writes a JSON string into the App Group's
-//  UserDefaults (`src/lib/widget.ts`) and asks WidgetKit to reload. This
-//  provider reads that string back. No network, no auth, no Firestore — a
-//  widget process has none of them.
+//  Data flow is unchanged and deliberately dumb: the RN app writes a JSON
+//  string into the App Group's UserDefaults (`src/lib/widget.ts`) and asks
+//  WidgetKit to reload. This provider reads that string back. No network, no
+//  auth, no Firestore — a widget process has none of them.
 //
-
-// MARK: - Shared contract (mirrors widget-snapshot.ts)
-
-/// Must equal `WIDGET_SNAPSHOT_KEY` in `packages/core/src/widget-snapshot.ts`.
-private let snapshotKey = "ignia.widget.snapshot.v1"
-
-/// Must equal `APP_GROUP` in `src/lib/widget.ts` and the entitlement in app.json.
-private let appGroup = "group.fit.ignia.app"
-
-/// Must equal `WIDGET_SNAPSHOT_VERSION`. A blob written by a newer app is
-/// rejected rather than partially decoded — during an app update the widget
-/// extension keeps running old code until the OS reloads it.
-private let snapshotVersion = 1
-
-private struct Snapshot: Codable {
-  let v: Int
-  let dateKey: String
-  let kcalConsumed: Int
-  let kcalTarget: Int
-  let proteinConsumed: Int
-  let proteinTarget: Int
-  let updatedMs: Double
-  let locale: String
-}
-
-/// Mirrors `WidgetMetric`: distance from target plus which side of it.
-private struct Metric {
-  let value: Int
-  let isOver: Bool
-
-  init(consumed: Int, target: Int) {
-    isOver = consumed > target
-    value = abs(target - consumed)
-  }
-}
-
-/// Mirrors `WidgetView`. The empty reasons are collapsed into one case because
-/// iOS renders all three identically; the TS side keeps them apart only so its
-/// tests can distinguish them. The locale rides along on BOTH cases — the empty
-/// state is a sentence, and hardcoding English here put "Open Ignia to start"
-/// on Spanish home screens.
-private enum View_ {
-  case empty(locale: String)
-  case ready(kcal: Metric, protein: Metric, locale: String)
-}
-
-/// Mirrors `parseWidgetSnapshot` + `widgetView`. Anything unreadable, foreign
-/// versioned, from another day, or without a calorie target collapses to
-/// `.empty` — never a thrown error, which would show the OS's "unable to load"
-/// placeholder and read as a crashed app.
-private func loadView(now: Date) -> View_ {
-  guard
-    let defaults = UserDefaults(suiteName: appGroup),
-    let raw = defaults.string(forKey: snapshotKey),
-    let data = raw.data(using: .utf8),
-    let snap = try? JSONDecoder().decode(Snapshot.self, from: data),
-    snap.v == snapshotVersion
-  else {
-    // Nothing readable, so there is no stored preference to honour — the one
-    // case where falling back to English is the only option.
-    return .empty(locale: "en")
-  }
-
-  guard snap.dateKey == localDateKey(now) else { return .empty(locale: snap.locale) }
-  guard snap.kcalTarget > 0 else { return .empty(locale: snap.locale) }
-
-  return .ready(
-    kcal: Metric(consumed: snap.kcalConsumed, target: snap.kcalTarget),
-    protein: Metric(consumed: snap.proteinConsumed, target: snap.proteinTarget),
-    locale: snap.locale
-  )
-}
-
-/// Mirrors `localDateKey` from `packages/core/src/date.ts`: `YYYY-MM-DD` in the
-/// device's *local* zone. Must not be UTC — the whole point of the date key is
-/// that it flips at the user's midnight, not at Greenwich's.
-private func localDateKey(_ date: Date) -> String {
-  let f = DateFormatter()
-  f.calendar = Calendar(identifier: .gregorian)
-  f.locale = Locale(identifier: "en_US_POSIX")
-  f.dateFormat = "yyyy-MM-dd"
-  return f.string(from: date)
-}
-
-// MARK: - Strings (mirrors src/widgets/strings.ts)
-
-private struct Strings {
-  let kcal: String
-  let left: String
-  let over: String
-  let protein: String
-  let empty: String
-}
-
-/// Keyed by the locale carried in the snapshot — our locale is a *profile*
-/// preference stored in Firestore, so the device locale would be wrong for
-/// anyone whose app language differs from their phone's.
-private func strings(_ locale: String) -> Strings {
-  switch locale {
-  case "es-PR":
-    return Strings(
-      kcal: "kcal", left: "restantes", over: "de más",
-      protein: "proteína", empty: "Abre Ignia para empezar")
-  default:
-    return Strings(
-      kcal: "kcal", left: "left", over: "over",
-      protein: "protein", empty: "Open Ignia to start")
-  }
-}
-
-private func grouped(_ n: Int) -> String {
-  let f = NumberFormatter()
-  f.numberStyle = .decimal
-  f.groupingSeparator = ","
-  return f.string(from: NSNumber(value: n)) ?? String(n)
-}
+//  Verified on a physical iPhone from TestFlight build 13 on 2026-08-03: kcal
+//  left and protein left render, and the numbers move after a logged meal.
+//
 
 // MARK: - Palette (mirrors src/theme.ts heroPanel family)
+//
+// Used by `systemSmall` ONLY. The accessory families never name a brand colour
+// — the Lock Screen renders them in the OS's tinted/vibrant mode, which
+// flattens orange and green toward the same tint, exactly where colour was
+// doing all the work of telling the two metrics apart. There hierarchy is
+// carried by weight and size (#33). Two palettes, split cleanly by family, so
+// there is no Swift copy of ADR-0014's rules to keep in step.
 
 private extension Color {
   /// `theme.ts` colours are hex strings; this is the only way to reuse the
@@ -159,7 +53,7 @@ private extension Color {
 
 private struct Entry: TimelineEntry {
   let date: Date
-  let view: View_
+  let face: Glance.Face
 }
 
 private struct Provider: TimelineProvider {
@@ -169,41 +63,39 @@ private struct Provider: TimelineProvider {
   func placeholder(in context: Context) -> Entry {
     Entry(
       date: Date(),
-      view: .ready(
-        kcal: Metric(consumed: 760, target: 2000),
-        protein: Metric(consumed: 92, target: 160),
-        locale: "en"))
+      face: Glance.face(
+        raw: """
+          {"v":1,"dateKey":"\(Glance.localDateKey(Date()))","kcalConsumed":1240,\
+          "kcalTarget":2000,"proteinConsumed":92,"proteinTarget":160,\
+          "updatedMs":\(Date().timeIntervalSince1970 * 1000),"locale":"en"}
+          """,
+        now: Date()))
   }
 
   func getSnapshot(in context: Context, completion: @escaping (Entry) -> Void) {
-    completion(Entry(date: Date(), view: loadView(now: Date())))
+    completion(Entry(date: Date(), face: Glance.load(now: Date())))
   }
 
   func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
     let now = Date()
-    let current = loadView(now: now)
-    var entries = [Entry(date: now, view: current)]
-
-    // Carry today's locale into the post-midnight blank. Rebuilding it as "en"
-    // would flip a Spanish widget to English at midnight and leave it there
-    // until the app is next opened.
-    let locale: String
-    switch current {
-    case let .ready(_, _, l): locale = l
-    case let .empty(l): locale = l
-    }
+    let current = Glance.load(now: now)
+    var entries = [Entry(date: now, face: current)]
 
     // Pre-schedule the rollover. The app calls `reloadWidget` on every log, so
     // in-day freshness is push-driven; this second entry exists for the one
     // moment nothing pushes — midnight, when today's numbers must blank even
     // if the app is never opened. Without it the widget would show yesterday's
     // "1,240 left" all through the next morning.
+    //
+    // The locale is carried into the blank on purpose. Rebuilding it as "en"
+    // would flip a Spanish widget to English at midnight and leave it there
+    // until the app is next opened.
     let cal = Calendar.current
     if let midnight = cal.nextDate(
       after: now, matching: DateComponents(hour: 0, minute: 0, second: 5),
       matchingPolicy: .nextTime)
     {
-      entries.append(Entry(date: midnight, view: .empty(locale: locale)))
+      entries.append(Entry(date: midnight, face: .empty(locale: current.locale)))
     }
 
     // `.atEnd` asks WidgetKit for a new timeline once the last entry is passed,
@@ -212,24 +104,26 @@ private struct Provider: TimelineProvider {
   }
 }
 
-// MARK: - UI
+// MARK: - Home Screen · systemSmall
 
-private struct TodayWidgetView: SwiftUI.View {
-  let entry: Entry
+private struct HomeView: SwiftUI.View {
+  let face: Glance.Face
 
   var body: some SwiftUI.View {
     // Locked design (WIDGET.md §"Open decisions"): text-first, kcal over
-    // protein. The ring is a deliberate fast-follow, not an omission.
+    // protein. The ring is a deliberate fast-follow, not an omission — which is
+    // why `systemSmall` still ignores `Metric.progress` even though the
+    // accessory families now consume it.
     VStack(alignment: .leading, spacing: 0) {
-      switch entry.view {
+      switch face {
       case let .empty(locale):
-        Text(strings(locale).empty)
+        Text(Glance.strings(locale ?? "en").empty)
           .font(.system(size: 13))
           .foregroundStyle(Color.igMuted)
 
-      case let .ready(kcal, protein, locale):
-        let s = strings(locale)
-        Text(grouped(kcal.value))
+      case let .ready(kcal, protein, snap):
+        let s = Glance.strings(snap.locale)
+        Text(Glance.grouped(kcal.value))
           .font(.system(size: 34, weight: .bold, design: .rounded))
           .foregroundStyle(Color.igKcal)
           .minimumScaleFactor(0.6)
@@ -237,7 +131,7 @@ private struct TodayWidgetView: SwiftUI.View {
         Text("\(s.kcal) \(kcal.isOver ? s.over : s.left)")
           .font(.system(size: 12))
           .foregroundStyle(Color.igMuted)
-        Text("\(grouped(protein.value))g \(s.protein) \(protein.isOver ? s.over : s.left)")
+        Text(Glance.proteinLine(protein, s))
           .font(.system(size: 13, weight: .semibold))
           .foregroundStyle(Color.igProtein)
           .minimumScaleFactor(0.7)
@@ -246,20 +140,132 @@ private struct TodayWidgetView: SwiftUI.View {
       }
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    .containerBackground(Color.igPanel, for: .widget)
+  }
+}
+
+// MARK: - Lock Screen · accessory families
+//
+// `.primary` / `.secondary` and `.tint(.primary)` only. No brand hex, no
+// `AccessoryWidgetBackground` beyond the empty circular ring, and no
+// `containerBackground` — it does not apply to accessory families.
+//
+// Nothing here reads `@Environment(\.widgetRenderingMode)`. Its exact semantics
+// are unverified (#33) and the design deliberately does not depend on them.
+
+private struct CircularView: SwiftUI.View {
+  let face: Glance.Face
+
+  var body: some SwiftUI.View {
+    // The slot never changes shape between states — same gauge, same centre
+    // glyph position — which matters most at midnight, the one transition we
+    // would rather not draw the eye to.
+    switch face {
+    case .empty:
+      Gauge(value: 0.0) {
+        Image(systemName: "flame")
+      }
+      .gaugeStyle(.accessoryCircularCapacity)
+
+    case let .ready(kcal, _, _):
+      Gauge(value: kcal.progress) {
+        // Wordless. There is no room for a unit here, and with `progress`
+        // clamped to 0...1 the ring alone cannot say "past target" — so the
+        // over-target state is carried by a single `+` glyph, which needs no
+        // es-PR translation.
+        Text(kcal.isOver ? "+" : "")
+      } currentValueLabel: {
+        Text(kcal.isOver ? "+\(Glance.grouped(kcal.value))" : Glance.grouped(kcal.value))
+          .minimumScaleFactor(0.5)
+          .lineLimit(1)
+      }
+      .gaugeStyle(.accessoryCircularCapacity)
+    }
+  }
+}
+
+private struct RectangularView: SwiftUI.View {
+  let face: Glance.Face
+
+  var body: some SwiftUI.View {
+    // The only family carrying protein — circular and inline are kcal-only by
+    // necessity, and the kcal-over-protein ranking is locked.
+    //
+    // NOTE the one declared divergence from the watch's rectangular view: there
+    // is no `as of` row here. On the phone the widget reads the App Group on
+    // the SAME device and the containing app's foreground reload is free, so
+    // the number is authoritative to within seconds. `as of 8:04 AM` under it
+    // at 1 PM would imply a doubt that does not exist — the same words carry
+    // opposite meaning on the two devices (#40 §3). The shared *spec* is
+    // `asOf: Date?`, nil here; the source is written twice on purpose (#38 §2).
+    VStack(alignment: .leading, spacing: 1) {
+      switch face {
+      case let .empty(locale):
+        Label(Glance.strings(locale ?? "en").empty, systemImage: "flame")
+          .font(.headline)
+          .lineLimit(1)
+          .minimumScaleFactor(0.7)
+
+      case let .ready(kcal, protein, snap):
+        let s = Glance.strings(snap.locale)
+        Text(Glance.kcalLine(kcal, s))
+          .font(.headline)
+          .lineLimit(1)
+          .minimumScaleFactor(0.7)
+        Gauge(value: kcal.progress) { EmptyView() }
+          .gaugeStyle(.accessoryLinearCapacity)
+          .tint(.primary)
+        Text(Glance.proteinLine(protein, s))
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .lineLimit(1)
+          .minimumScaleFactor(0.7)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}
+
+private struct InlineView: SwiftUI.View {
+  let face: Glance.Face
+
+  var body: some SwiftUI.View {
+    switch face {
+    case let .empty(locale):
+      Label(Glance.strings(locale ?? "en").emptyShort, systemImage: "flame")
+    case let .ready(kcal, _, snap):
+      Label(Glance.kcalLine(kcal, Glance.strings(snap.locale)), systemImage: "flame")
+    }
+  }
+}
+
+private struct TodayWidgetView: SwiftUI.View {
+  @Environment(\.widgetFamily) private var family
+  let entry: Entry
+
+  var body: some SwiftUI.View {
+    Group {
+      switch family {
+      case .accessoryCircular: CircularView(face: entry.face)
+      case .accessoryRectangular: RectangularView(face: entry.face)
+      case .accessoryInline: InlineView(face: entry.face)
+      default: HomeView(face: entry.face)
+      }
+    }
     // Tapping opens the Today screen with the add-entry sheet already up —
     // the same `?openAdd` param the in-app FAB uses. The widget is meant to
-    // drive logging, not just display it.
+    // drive logging, not just display it. On the Lock Screen this lands in an
+    // add-entry modal after Face ID (#41 owns that landing).
     .widgetURL(URL(string: "ignia://?openAdd=1"))
-    .containerBackground(Color.igPanel, for: .widget)
   }
 }
 
 @main
 struct TodayWidget: Widget {
-  // Must match `WIDGET_NAME` in `src/lib/widget.ts` — it's the `kind` passed to
-  // `ExtensionStorage.reloadWidget`, and a mismatch means our reload requests
-  // silently address a widget that doesn't exist.
-  let kind = "Today"
+  // Must match `Glance.widgetKind` / `WIDGET_NAME` in `src/lib/widget.ts` —
+  // it's the `kind` passed to `ExtensionStorage.reloadWidget`, and a mismatch
+  // means our reload requests silently address a widget that doesn't exist.
+  let kind = Glance.widgetKind
 
   var body: some WidgetConfiguration {
     StaticConfiguration(kind: kind, provider: Provider()) { entry in
@@ -267,8 +273,13 @@ struct TodayWidget: Widget {
     }
     .configurationDisplayName("Today")
     .description("Calories and protein left today.")
-    // Small only for v1, per the locked decisions. Medium is cheap to add
-    // later once this face is verified on a device.
-    .supportedFamilies([.systemSmall])
+    // `.accessoryCorner` is deliberately absent: it is the only family with no
+    // Lock Screen counterpart, so it would be the only net-new layout, using an
+    // idiom (`widgetLabel`, curved gauge text) nothing else in the repo uses.
+    // Cost accepted: we are absent from the corner slots of the Infograph
+    // faces (#40 §0).
+    .supportedFamilies([
+      .systemSmall, .accessoryCircular, .accessoryRectangular, .accessoryInline,
+    ])
   }
 }

--- a/scripts/doctor.mjs
+++ b/scripts/doctor.mjs
@@ -760,6 +760,77 @@ function checkEasQuota() {
 }
 
 // ═══ 4. Locale key parity ═══════════════════════════════════════════════
+/**
+ * Is the Sentry auth token actually good?
+ *
+ * On 2026-08-03 this cost an Android build. `@sentry/react-native`'s Gradle
+ * integration uploads source maps and native symbols as a **build task**, and
+ * a bad token fails that task, which fails the whole build:
+ *
+ *     sentry reported an error: Invalid token (http status: 401)
+ *     > Task :app:createBundleReleaseJsAndAssets_SentryUpload_… FAILED
+ *
+ * The build sat in the free-tier queue for **two hours** before a worker
+ * picked it up, ran Gradle for five minutes, and died on an HTTP 401. One of
+ * the 15 monthly Android builds, spent on an auth failure that is knowable in
+ * one request before anything is queued.
+ *
+ * Two properties make this worth a check rather than a habit. It is
+ * **invisible until the build runs** — nothing local reads the token — and it
+ * **breaks by sitting still**: rotating or revoking the token in Sentry
+ * changes nothing here until the next build. There are three copies (this
+ * machine's `.env.local`, both EAS environments, the GitHub Actions secret)
+ * and no mechanism keeps them in step.
+ *
+ * This checks only the copy on this machine, which is the one a human is most
+ * likely to have updated last. It cannot read the EAS or GitHub copies —
+ * secrets are write-only there by design — so a PASS means "the token you have
+ * is good", not "every copy is good". Re-set all three together; that is the
+ * only guarantee available.
+ */
+async function checkSentryToken() {
+  const name = 'SENTRY_AUTH_TOKEN authenticates';
+  const org = process.env.SENTRY_ORG || 'gabriel-bermudez';
+
+  if (!has('.env.local')) return skip(G3, name, 'no .env.local on this machine');
+  try {
+    process.loadEnvFile(resolve(root, '.env.local'));
+  } catch (e) {
+    return skip(G3, name, `could not read .env.local: ${e.message}`);
+  }
+
+  const token = process.env.SENTRY_AUTH_TOKEN;
+  if (!token) return skip(G3, name, 'SENTRY_AUTH_TOKEN is not set in .env.local');
+
+  let res;
+  try {
+    res = await fetch(`https://sentry.io/api/0/organizations/${org}/`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(20_000),
+    });
+  } catch (e) {
+    return skip(G3, name, `could not reach sentry.io: ${e.message}`);
+  }
+
+  if (res.ok) {
+    return pass(G3, name, `token is valid for org ${org} (EAS + GitHub copies are unreadable — re-set all three together)`);
+  }
+  if (res.status === 401) {
+    return fail(
+      G3,
+      name,
+      `sentry.io rejects the token in .env.local (401). A Gradle/EAS build WILL fail on ` +
+        `SentryUpload after its full queue wait. Fix .env.local, then re-set both EAS ` +
+        `environments (eas env:create --environment production|preview --name SENTRY_AUTH_TOKEN ` +
+        `--visibility secret --force) and the GitHub secret (gh secret set SENTRY_AUTH_TOKEN).`,
+    );
+  }
+  if (res.status === 403) {
+    return fail(G3, name, `token authenticates but lacks scope for org ${org} (403) — needs org:read + project:releases`);
+  }
+  return skip(G3, name, `unexpected HTTP ${res.status} from sentry.io`);
+}
+
 const G4 = '4. i18n key parity';
 
 function diffKeys(group, name, a, b, labelA, labelB) {
@@ -949,6 +1020,7 @@ if (NO_CLOUD) {
   skip(G3, `Cloud Scheduler jobs <= ${MAX_SCHEDULER_JOBS}`, '--no-cloud');
   skip(G3, `active secret versions <= ${MAX_SECRET_VERSIONS}`, '--no-cloud');
   skip(G3, 'STATUS.md §3 matches the EAS iOS quota', '--no-cloud');
+  skip(G3, 'SENTRY_AUTH_TOKEN authenticates', '--no-cloud');
   skip(G5, 'STATUS.md §4 matches open issues', '--no-cloud');
 } else {
   await checkRulesMatchReleased().catch((e) =>
@@ -961,6 +1033,9 @@ if (NO_CLOUD) {
   guard(G3, `Cloud Scheduler jobs <= ${MAX_SCHEDULER_JOBS}`, checkSchedulerJobs);
   guard(G3, `active secret versions <= ${MAX_SECRET_VERSIONS}`, checkSecretVersions);
   guard(G3, 'STATUS.md §3 matches the EAS iOS quota', checkEasQuota);
+  await checkSentryToken().catch((e) =>
+    fail(G3, 'SENTRY_AUTH_TOKEN authenticates', `check threw: ${e.message}`),
+  );
   guard(G5, 'STATUS.md §4 matches open issues', checkStatusVsIssues);
 }
 


### PR DESCRIPTION
Writes every part of the Apple Watch surface that does not need a Mac, so the two tickets that **do** (#46 layout readout, #47 Xcode compile) become the batched sittings they were designed to be rather than sittings that also have to design and write Swift.

This implements decisions already closed on the #31 map — #33, #37, #38, #39, #40, #43, #44 — and re-opens none of them.

## What's here

| | |
|---|---|
| `targets/_shared/Glance.swift` | **The one Swift mirror** of `packages/core/src/widget-snapshot.ts`. apple-targets globs `_shared/*` into every target, so this single file reaches the iPhone widget, the watch app and the complication (#38 §1). Foundation-only — it is linked into the main app target too. |
| `targets/widget/index.swift` | `systemSmall` unchanged (the face verified on device 2026-08-03), **plus** the three Lock Screen accessory families (#33). |
| `targets/watch/index.swift` | The watch app: `WCSession` delegate, `.backgroundTask(.watchConnectivity)`, App Group write, `reloadAllTimelines`, and #39's one-screen read-only mirror. |
| `targets/watch-widget/index.swift` | Complication — circular, rectangular, inline. |
| `modules/watch-link/` | The repo's **first custom Expo Module**. |
| `src/lib/widget.ts` | One line at the existing `persist()` call site; an explicit clear in `clearWidget()`. |

## The three decisions most likely to be undone by accident later

**`.lineLimit(1)` inside `ViewThatFits` is a correctness prerequisite, not styling.** `ViewThatFits` measures a child's *ideal* size, and a `Text`'s ideal height is one line however long the string is. Remove the line limit and the 4-row candidate reports "fits", gets selected, then wraps at render — clipping, hardest in es-PR. Anyone who later removes it to "let the Spanish string breathe" re-arms the exact bug the branch exists to prevent.

**Views are deliberately not shared.** `_shared` is linked into the main app target unconditionally, so it compiles against the phone app's iOS floor. `Gauge` is iOS 16+, `.containerBackground` is iOS 17+. The line: what can silently show wrong *numbers* is shared; what can only look wrong is not.

**The watch podspec floor sits below the app's 16.4, on purpose.** A podspec floor *above* the app's deployment target is what made Expo's autolinking silently drop `ExtensionStorage` and kill the iPhone widget for two builds (`STATUS.md` §3).

## What was verified, and what was not

Verified on this machine:
- `tsc` clean; eslint clean (only pre-existing `require()` warnings).
- Both `expo-target.config.js` files evaluate and resolve the App Group entitlement correctly.
- `expo-modules-autolinking search -p apple` resolves `watch-link` → `WatchLinkModule`. **This is the check that matters most here** — an unseen module is precisely how `ExtensionStorage` went missing, and it is why the third-party WatchConnectivity package was rejected in #37 §3.

**Not verified: none of this Swift has ever been through a compiler.** Windows, no Xcode, and `expo prebuild -p ios` does not run here (WSL is present but has no node). Do not read "written" as "works".

## Blockers this does not clear

1. **A Mac** — #46 and #47.
2. **Credentials, which is a separate gate and bites first.** The scheme gains two brand-new bundle ids, `fit.ignia.app.watchkitapp` and `fit.ignia.app.watchkitapp.complication`, neither of which exists in the Apple portal. EAS cannot mint those unattended; `production` has still never had its interactive pass. Credential failures cost no build quota — they happen before the build is created.

No `CHANGELOG.md` entry: nothing shipped. `STATUS.md` §2 carries it as merged-and-in-no-binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)