### PR TITLE
fix(trends): key every Trends window by the user's day, not midnight

### DIFF
--- a/apps/mobile/src/hooks/useSleepTrends.ts
+++ b/apps/mobile/src/hooks/useSleepTrends.ts
@@ -82,10 +82,10 @@ export function useSleepTrends(
   // render is fine and per focus is what matters — a card left open across
   // midnight should move on, and this screen re-derives on refocus anyway.
   const dateKeys = useMemo(
-    // NOTE: boundary-aware, while the rest of `useTrends` (insights, budget,
-    // loggedThisWeek) still defaults to MIDNIGHT. That is a pre-existing gap in
-    // ADR-0030 step 3, not something introduced here — but it is the reason
-    // this line is not simply `trailingDateKeys(SLEEP_WINDOW_DAYS, new Date())`.
+    // Boundary-aware, like every other window on this screen. It was the ONLY
+    // boundary-aware one for a while, which meant Trends keyed the sleep card
+    // and the insight/budget cards to two different calendars; `useTrends`
+    // now threads the same boundary through all of them.
     // Writing a NEW pairing midnight-only would be adding a latent bug on
     // purpose; the pairing between a night and the day's eating is the entire
     // claim this card makes.

--- a/apps/mobile/src/hooks/useTrends.ts
+++ b/apps/mobile/src/hooks/useTrends.ts
@@ -8,6 +8,7 @@ import {
   type WeightPoint,
   addDays,
   basalMifflinStJeor,
+  dayBoundaryOf,
   computeWeeklyBudget,
   computeWeeklyInsights,
   dailyTargets,
@@ -75,32 +76,44 @@ export function useTrends(): TrendsState {
     [profile, logs, weights],
   );
 
+  // The user's day start (ADR-0030). EVERY window below is keyed by it, not by
+  // midnight: the sleep card was made boundary-aware when it shipped and the
+  // rest of this hook was not, so on any non-midnight boundary one screen was
+  // keying two cards to two different calendars — the sleep card counting a
+  // 01:00 entry as the previous day while the insight and budget cards counted
+  // it as the current one. `MIDNIGHT` is the default everywhere, and under it
+  // `dayKeyAt` IS the calendar date, so no existing account moves.
+  const boundary = useMemo(() => dayBoundaryOf(profile), [profile]);
+
   const insights = useMemo(() => {
     const today = new Date();
-    const summaries = summarizeDays(trailingDateKeys(INSIGHT_DAYS, today), logs, weights);
-    const points = weightPointsForDays(weights, SLOPE_WINDOW_DAYS, today);
+    const summaries = summarizeDays(
+      trailingDateKeys(INSIGHT_DAYS, today, boundary), logs, weights, boundary,
+    );
+    const points = weightPointsForDays(weights, SLOPE_WINDOW_DAYS, today, boundary);
     return computeWeeklyInsights(summaries, targets.calorieTarget, points, targets.proteinTarget);
-  }, [logs, weights, targets]);
+  }, [logs, weights, targets, boundary]);
 
   const loggedThisWeek = useMemo(() => {
     const today = new Date();
-    return summarizeDays(trailingDateKeys(INSIGHT_DAYS, today), logs, weights)
-      .filter((d) => d.mealCount > 0 && d.totalCalories > 0).length;
-  }, [logs, weights]);
+    return summarizeDays(
+      trailingDateKeys(INSIGHT_DAYS, today, boundary), logs, weights, boundary,
+    ).filter((d) => d.mealCount > 0 && d.totalCalories > 0).length;
+  }, [logs, weights, boundary]);
 
   const weightSeries = useMemo<number[]>(
-    () => weightSeriesForDays(weights, SPARK_DAYS, new Date()),
-    [weights],
+    () => weightSeriesForDays(weights, SPARK_DAYS, new Date(), boundary),
+    [weights, boundary],
   );
 
   const budget = useMemo<WeeklyBudget | null>(() => {
     // ISO-local week (Monday-start): the seven Mon→Sun date keys and today's
     // 1-based position. Monday is at most 6 days back, so the log window covers
     // the elapsed week.
-    const week = isoWeek(new Date());
-    const days = summarizeDays(week.keys, logs, weights);
+    const week = isoWeek(new Date(), boundary);
+    const days = summarizeDays(week.keys, logs, weights, boundary);
     return computeWeeklyBudget(days, week.daysElapsed, targets.calorieTarget);
-  }, [logs, weights, targets]);
+  }, [logs, weights, targets, boundary]);
 
   const basalKcal = useMemo(() => {
     if (!profile || profile.heightIn == null || profile.age == null || profile.sex == null) return 0;

--- a/packages/core/src/log-window.test.ts
+++ b/packages/core/src/log-window.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { type DayBoundary, MIDNIGHT } from './day-boundary';
 import {
   LOG_WINDOW_ROWS,
   RECENT_LOGS_ROWS,
@@ -56,6 +57,44 @@ describe('weightPointsForDays', () => {
       { dateKey: '2026-08-11', weightLb: 180.8 },
       { dateKey: '2026-08-12', weightLb: 180.4 },
     ]);
+  });
+});
+
+/**
+ * ADR-0030 step 3. These two windows took `boundary` late: the Trends screen
+ * had a boundary-aware sleep card sitting beside a midnight-only weight trend
+ * and calorie insight, so one screen keyed two cards to two different
+ * calendars. The ratchet in `scripts/check-day-boundary.mjs` cannot catch that
+ * class — it greps for `calendarDateKey`, and none of these call it.
+ */
+describe('the weight windows respect the day boundary', () => {
+  /** Days start at 03:00 from 2026-01-01 on. */
+  const THREE_AM: DayBoundary = [{ from: '2026-01-01' as never, hour: 3 }];
+  /** 01:00 Wednesday — under a 3am start this is still TUESDAY. */
+  const WED_1AM = new Date(2026, 7, 12, 1, 0);
+  const weights = { '2026-08-10': 181, '2026-08-11': 180.8, '2026-08-12': 180.4 };
+
+  it('defaults to midnight, so no existing account moves', () => {
+    expect(weightSeriesForDays(weights, 2, WED_1AM)).toEqual([180.8, 180.4]);
+    expect(weightSeriesForDays(weights, 2, WED_1AM, MIDNIGHT)).toEqual([180.8, 180.4]);
+  });
+
+  it('anchors the series on the user day, not the calendar date', () => {
+    // 01:00 Wed under a 3am start is Tuesday, so the trailing 2 days are
+    // Mon+Tue — Wednesday's weigh-in has not happened in her day yet.
+    expect(weightSeriesForDays(weights, 2, WED_1AM, THREE_AM)).toEqual([181, 180.8]);
+  });
+
+  it('anchors the points the same way, keys included', () => {
+    expect(weightPointsForDays(weights, 2, WED_1AM, THREE_AM)).toEqual([
+      { dateKey: '2026-08-10', weightLb: 181 },
+      { dateKey: '2026-08-11', weightLb: 180.8 },
+    ]);
+  });
+
+  it('agrees with trailingDateKeys, which is the window everything else uses', () => {
+    expect(weightPointsForDays(weights, 2, WED_1AM, THREE_AM).map((p) => p.dateKey))
+      .toEqual(trailingDateKeys(2, WED_1AM, THREE_AM).filter((k) => k in weights));
   });
 });
 

--- a/packages/core/src/log-window.ts
+++ b/packages/core/src/log-window.ts
@@ -60,14 +60,20 @@ export function trailingDateKeys(n: number, now: Date, boundary: DayBoundary = M
 }
 
 /** One weight per day over the trailing `n` days, oldest first, **days with no
- *  weigh-in dropped** — a gap must not plot as a zero. */
+ *  weigh-in dropped** — a gap must not plot as a zero.
+ *
+ *  Takes `boundary` for the same reason every other window does (ADR-0030): a
+ *  weigh-in at 01:00 under a 03:00 day start belongs to the previous day, and
+ *  a window that disagrees with the one the intake cards use puts the weight
+ *  trend and the calorie trend on two different calendars. */
 export function weightSeriesForDays(
   weights: Readonly<Record<string, number>>,
   n: number,
   now: Date,
+  boundary: DayBoundary = MIDNIGHT,
 ): number[] {
   const out: number[] = [];
-  for (const key of trailingDateKeys(n, now)) {
+  for (const key of trailingDateKeys(n, now, boundary)) {
     const v = weights[key];
     if (typeof v === 'number') out.push(v);
   }
@@ -87,9 +93,10 @@ export function weightPointsForDays(
   weights: Readonly<Record<string, number>>,
   n: number,
   now: Date,
+  boundary: DayBoundary = MIDNIGHT,
 ): DatedWeight[] {
   const out: DatedWeight[] = [];
-  for (const key of trailingDateKeys(n, now)) {
+  for (const key of trailingDateKeys(n, now, boundary)) {
     const v = weights[key];
     if (typeof v === 'number') out.push({ dateKey: key, weightLb: v });
   }


### PR DESCRIPTION
Closes nothing — this gap was found while building #81 and was never ticketed. It is the last of ADR-0030 step 3 that a user can actually see.

The sleep card shipped boundary-aware (ADR-0033); the rest of `useTrends` did not. So on any non-midnight boundary **one screen keyed two cards to two different calendars** — the sleep card counting a 01:00 entry as the previous day while `insights`, `loggedThisWeek` and `budget` counted it as the current one.

`insights`, `loggedThisWeek`, `weightSeries` and `budget` now thread `dayBoundaryOf(profile)` through `trailingDateKeys`, `summarizeDays`, `isoWeek` and the two weight windows.

`weightSeriesForDays` / `weightPointsForDays` grew an optional `boundary` in `packages/core`, for the same reason every other window has one: a weigh-in at 01:00 under a 03:00 day start belongs to the previous day, and a weight trend on a different calendar from the calorie trend is the same bug one level down. Both default to `MIDNIGHT`, under which `dayKeyAt` **is** the calendar date — so no existing account moves and the frozen web app (ADR-0022) is untouched. Verified: web has its own private `isoWeek` and does not call either helper.

**`npm run check:day-boundary` does not catch this class** and still reports 10 calls in 3 files — it greps for `calendarDateKey`, and none of these call it. Covered instead by four tests in `log-window.test.ts` asserting both the midnight default and the 3am anchor.

core 1233 · mobile 438 · web 206 · tsc clean on all four units.

JS-only → ships by OTA on both platforms, no binary.