### PR TITLE
fix(mobile): stop waiting on Firebase to say what is already on disk (#83)

### DIFF
--- a/apps/mobile/src/__tests__/persisted-session.test.ts
+++ b/apps/mobile/src/__tests__/persisted-session.test.ts
@@ -1,0 +1,48 @@
+import { parsePersistedSession } from '@/lib/persisted-session';
+
+/**
+ * #83 — the gate reads Firebase's own persisted session off disk rather than
+ * waiting ~8.7 s for `onAuthStateChanged` to validate a token over a network
+ * that is not answering.
+ *
+ * The blob is the SDK's shape, not ours, so these pin exactly what we depend
+ * on and — more importantly — that every malformed form degrades to `null`,
+ * which means "wait for Firebase like we always did" rather than "routed
+ * somewhere wrong".
+ */
+describe('parsePersistedSession', () => {
+  it('reads the uid and the verified flag', () => {
+    expect(
+      parsePersistedSession(JSON.stringify({ uid: 'abc123', emailVerified: true, extra: 'ignored' })),
+    ).toEqual({ uid: 'abc123', emailVerified: true });
+  });
+
+  it('treats a MISSING emailVerified as NOT verified', () => {
+    // The dangerous direction: guessing `true` would route an unverified
+    // signup into the app, where every write then fails the rules'
+    // email_verified gate and the user sees saves silently not happening.
+    expect(parsePersistedSession(JSON.stringify({ uid: 'abc123' }))).toEqual({
+      uid: 'abc123',
+      emailVerified: false,
+    });
+  });
+
+  it('does not accept a truthy non-true emailVerified', () => {
+    expect(parsePersistedSession(JSON.stringify({ uid: 'a', emailVerified: 'yes' }))?.emailVerified).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ['no stored key', null],
+    ['empty string', ''],
+    ['not JSON', '{not json'],
+    ['JSON that is not an object', '"a string"'],
+    ['null literal', 'null'],
+    ['object with no uid', '{"emailVerified":true}'],
+    ['uid of the wrong type', '{"uid":12345}'],
+    ['empty uid', '{"uid":""}'],
+  ])('returns null for %s — the gate then just waits', (_label, raw) => {
+    expect(parsePersistedSession(raw)).toBeNull();
+  });
+});

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -7,17 +7,18 @@ import { useFonts } from '@expo-google-fonts/manrope/useFonts';
 import { Slot, useRouter, useSegments } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useState } from 'react';
-import { LogBox, StyleSheet, View } from 'react-native';
+import { LogBox, StyleSheet, Text, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { AuthProvider, GATE_T0, useAuth } from '@/lib/auth';
+import { AuthProvider, useAuth } from '@/lib/auth';
 import { useIsOffline } from '@/lib/connectivity';
 import { assessRoute, shouldShowSplash } from '@/lib/onboarding-gate';
 import { BrandLoader } from '@/components/BrandLoader';
-import { I18nProvider } from '@/i18n';
+import { I18nProvider, useT } from '@/i18n';
 import { Sentry } from '@/lib/sentry';
 import { ThemeProvider, useTheme } from '@/lib/theme-context';
+import { font, space } from '@/theme';
 
 // Silence Expo Go's expo-notifications warnings: we use LOCAL notifications
 // (which work in Expo Go); remote push is deferred to a dev build (ADR-0015),
@@ -27,13 +28,33 @@ LogBox.ignoreLogs([
   '`expo-notifications` functionality is not fully supported in Expo Go',
 ]);
 
+/**
+ * How long the splash stays wordless before it admits it is waiting on
+ * something. Past this the user has been looking at a logo long enough to
+ * wonder whether the app is dead (#83) — and the honest answer costs one line.
+ */
+const SPLASH_EXPLAIN_AFTER_MS = 5000;
+
 /** Full-screen branded loading overlay while auth/profile/fonts settle, on
  *  the active theme's canvas so the handoff has no color flash. */
 function Splash() {
   const { colors } = useTheme();
+  const t = useT();
+  const [slow, setSlow] = useState(false);
+  useEffect(() => {
+    const id = setTimeout(() => setSlow(true), SPLASH_EXPLAIN_AFTER_MS);
+    return () => clearTimeout(id);
+  }, []);
   return (
     <View style={[styles.splash, { backgroundColor: colors.paper }]}>
       <BrandLoader />
+      {/* Deliberately no Retry button. The only recovery from here is a
+          restart, and a restart does not help when the cause is that the
+          network is not answering — so a button would promise a fix it cannot
+          deliver. Saying what is happening is the part that was missing. */}
+      {slow ? (
+        <Text style={[styles.splashNote, { color: colors.muted }]}>{t('splash.stillConnecting')}</Text>
+      ) : null}
     </View>
   );
 }
@@ -72,7 +93,7 @@ function useGaveUpWaiting(waiting: boolean): boolean {
 /** Redirects between the authed tab group and the sign-in screen as auth
  *  state settles. The `(app)` group holds every signed-in surface. */
 function AuthGate({ fontsReady }: { fontsReady: boolean }) {
-  const { user, initializing, profile, profileLoading, profileConfirmed, emailVerified } = useAuth();
+  const { sessionUid, initializing, profile, profileLoading, profileConfirmed, emailVerified } = useAuth();
   const offline = useIsOffline();
   const segments = useSegments();
   const router = useRouter();
@@ -80,12 +101,14 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
   // One `assessRoute` call feeding both the navigation and the splash — they
   // are the same question and used to be asked twice, which is how they drifted
   // apart in the first place.
-  const serverGaveUp = useGaveUpWaiting(!!user && (profileLoading || !profileConfirmed));
+  const serverGaveUp = useGaveUpWaiting(!!sessionUid && (profileLoading || !profileConfirmed));
   // `'app'` when there is nobody to route: signed out (or unverified) there is
   // no profile to wait for, and letting `assessRoute` answer `'wait'` off a null
   // profile would pin the splash over the sign-in screen.
   const decision =
-    user && emailVerified ? assessRoute({ profile, profileConfirmed, offline, serverGaveUp }) : 'app';
+    sessionUid && emailVerified
+      ? assessRoute({ profile, profileConfirmed, offline, serverGaveUp })
+      : 'app';
 
   useEffect(() => {
     if (initializing) return;
@@ -98,7 +121,12 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
     // clipped its last row.
     const onTour = route === 'tour';
 
-    if (!user) {
+    // `sessionUid`, not `user`: before Firebase answers this may be the session
+    // read off disk (#83). Redirecting to /sign-in on a slow network would tell
+    // a signed-in user they had been logged out, which is the one outcome worse
+    // than waiting. When the real event lands it wins — including when it says
+    // signed out, which lands here and redirects properly.
+    if (!sessionUid) {
       if (inApp || onOnboarding || onVerify || onTour) router.replace('/sign-in');
       return;
     }
@@ -130,7 +158,7 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
     // Completed users live in (app); leave them on /onboarding when they open
     // it deliberately (Settings → Edit goals / redo).
     if (!inApp && !onOnboarding && !onTour) router.replace('/(app)');
-  }, [user, initializing, emailVerified, decision, segments, router]);
+  }, [sessionUid, initializing, emailVerified, decision, segments, router]);
 
   // Always mount <Slot/> so the navigator exists when the redirect effect
   // fires; cover it with the splash while auth/profile/fonts settle.
@@ -139,7 +167,7 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
   // The latch, and the reasoning behind it, live in `onboarding-gate.ts` so the
   // decision can be tested without a router, a navigator or a Firebase session
   // — same split as `assessRoute`.
-  const uid = user?.uid ?? null;
+  const uid = sessionUid;
   const [settledUid, setSettledUid] = useState<string | null>(null);
   // Latched during render, not in an effect: an effect runs a frame later, and
   // that frame is exactly when a flap would slip a full-screen overlay in. The
@@ -148,14 +176,6 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
   const nextSettledUid = !uid ? null : gateSettled ? uid : settledUid;
   if (nextSettledUid !== settledUid) setSettledUid(nextSettledUid);
   const showSplash = shouldShowSplash({ gateSettled, uid, settledUid: nextSettledUid });
-  // TEMP instrumentation for #83 — removed before the fix ships.
-  useEffect(() => {
-    console.log(
-      `[GATE] render t=${Date.now() - GATE_T0}ms showSplash=${showSplash} initializing=${initializing}` +
-      ` fontsReady=${fontsReady} decision=${decision} serverGaveUp=${serverGaveUp}` +
-      ` profileLoading=${profileLoading} profileConfirmed=${profileConfirmed} offline=${offline} user=${uid ? 'yes' : 'no'}`,
-    );
-  }, [showSplash, initializing, fontsReady, decision, serverGaveUp, profileLoading, profileConfirmed, offline, uid]);
   return (
     <>
       <Slot />
@@ -178,6 +198,12 @@ const styles = StyleSheet.create({
     // branded loader fully covers it instead of the "+" peeking through.
     zIndex: 100,
     elevation: 100,
+  },
+  // Sits under the loader rather than replacing it: the brand mark is what
+  // says "this is still Ignia", the line is what says "and it is still trying".
+  splashNote: {
+    marginTop: space.lg,
+    fontSize: font.small,
   },
 });
 

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -11,7 +11,7 @@ import { LogBox, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import { AuthProvider, useAuth } from '@/lib/auth';
+import { AuthProvider, GATE_T0, useAuth } from '@/lib/auth';
 import { useIsOffline } from '@/lib/connectivity';
 import { assessRoute, shouldShowSplash } from '@/lib/onboarding-gate';
 import { BrandLoader } from '@/components/BrandLoader';
@@ -148,6 +148,14 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
   const nextSettledUid = !uid ? null : gateSettled ? uid : settledUid;
   if (nextSettledUid !== settledUid) setSettledUid(nextSettledUid);
   const showSplash = shouldShowSplash({ gateSettled, uid, settledUid: nextSettledUid });
+  // TEMP instrumentation for #83 — removed before the fix ships.
+  useEffect(() => {
+    console.log(
+      `[GATE] render t=${Date.now() - GATE_T0}ms showSplash=${showSplash} initializing=${initializing}` +
+      ` fontsReady=${fontsReady} decision=${decision} serverGaveUp=${serverGaveUp}` +
+      ` profileLoading=${profileLoading} profileConfirmed=${profileConfirmed} offline=${offline} user=${uid ? 'yes' : 'no'}`,
+    );
+  }, [showSplash, initializing, fontsReady, decision, serverGaveUp, profileLoading, profileConfirmed, offline, uid]);
   return (
     <>
       <Slot />

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -93,7 +93,8 @@ function useGaveUpWaiting(waiting: boolean): boolean {
 /** Redirects between the authed tab group and the sign-in screen as auth
  *  state settles. The `(app)` group holds every signed-in surface. */
 function AuthGate({ fontsReady }: { fontsReady: boolean }) {
-  const { sessionUid, initializing, profile, profileLoading, profileConfirmed, emailVerified } = useAuth();
+  const { sessionUid, sessionPresumed, initializing, profile, profileLoading, profileConfirmed, emailVerified } =
+    useAuth();
   const offline = useIsOffline();
   const segments = useSegments();
   const router = useRouter();
@@ -135,10 +136,17 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
     // providers return verified emails, so they fall straight through. Once
     // verified, the routing below (which sees onVerify as neither inApp nor
     // onOnboarding) sends them to onboarding or the app.
-    if (!emailVerified) {
+    // A PRESUMED session never routes to verify-email (#83). The flag comes
+    // off a disk blob that can be stale — Firebase updates it on reload — and
+    // telling an already-verified user to go and verify their email is worse
+    // than the second or two it costs to wait for the real answer. Once
+    // Firebase has spoken, `sessionPresumed` is false and this behaves exactly
+    // as it always did.
+    if (!emailVerified && !sessionPresumed) {
       if (!onVerify) router.replace('/verify-email');
       return;
     }
+    if (!emailVerified) return;
     // Signed in and verified. Where to go is decided by `assessRoute`, which
     // carries the reasoning and is tested on its own — this effect only
     // performs the navigation.
@@ -158,7 +166,7 @@ function AuthGate({ fontsReady }: { fontsReady: boolean }) {
     // Completed users live in (app); leave them on /onboarding when they open
     // it deliberately (Settings → Edit goals / redo).
     if (!inApp && !onOnboarding && !onTour) router.replace('/(app)');
-  }, [sessionUid, initializing, emailVerified, decision, segments, router]);
+  }, [sessionUid, sessionPresumed, initializing, emailVerified, decision, segments, router]);
 
   // Always mount <Slot/> so the navigator exists when the redirect effect
   // fires; cover it with the splash while auth/profile/fonts settle.

--- a/apps/mobile/src/i18n/en.ts
+++ b/apps/mobile/src/i18n/en.ts
@@ -178,6 +178,7 @@ export const en = {
   // Shown when the OS refuses to hand a web link to anything — Screen
   // Time, an MDM profile, no browser able to claim https. The URL is in
   // the body so the reader can still get there by hand.
+  'splash.stillConnecting': 'Still connecting…',
   'link.failedTitle': "Couldn't open that link",
   'link.failedBody': 'Your device blocked it. Open this in your browser instead:\n\n{url}',
   'whatsNew.title': "What's new",

--- a/apps/mobile/src/i18n/es-PR.ts
+++ b/apps/mobile/src/i18n/es-PR.ts
@@ -171,6 +171,7 @@ export const esPR: Record<I18nKey, string> = {
   // Shown when the OS refuses to hand a web link to anything — Screen
   // Time, an MDM profile, no browser able to claim https. The URL is in
   // the body so the reader can still get there by hand.
+  'splash.stillConnecting': 'Aún conectando…',
   'link.failedTitle': 'No se pudo abrir ese enlace',
   'link.failedBody': 'Tu dispositivo lo bloqueó. Abre esto en tu navegador:\n\n{url}',
   'whatsNew.title': 'Novedades',

--- a/apps/mobile/src/i18n/pt-BR.ts
+++ b/apps/mobile/src/i18n/pt-BR.ts
@@ -167,6 +167,7 @@ export const ptBR = {
   // Shown when the OS refuses to hand a web link to anything — Screen
   // Time, an MDM profile, no browser able to claim https. The URL is in
   // the body so the reader can still get there by hand.
+  'splash.stillConnecting': 'Ainda conectando…',
   'link.failedTitle': 'Não foi possível abrir esse link',
   'link.failedBody': 'O seu aparelho bloqueou. Abra isto no seu navegador:\n\n{url}',
   'whatsNew.title': 'Novidades',

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -53,13 +53,19 @@ export { LinkError } from './link-error';
 export type { LinkableProvider, PendingLink } from './link-error';
 import { auth, functions } from './firebase';
 
-/** TEMP instrumentation for #83 — removed before the fix ships. */
-export const GATE_T0 = Date.now();
+/**
+ * How long to wait for Firebase before falling back to the session on disk.
+ *
+ * Comfortably past the ~771 ms a healthy launch takes and far short of the
+ * ~8,690 ms a dead network costs, both measured on the LG G6 (#83).
+ */
+const PRESUMED_SESSION_AFTER_MS = 1200;
 import { ensureProfile, subscribeProfile } from './ledger';
 import { registerAppleRefreshToken } from './appleSignin';
 import { addBreadcrumb, captureError, setSentryUser } from './sentry';
 import { clearQuickAdd } from './quick-add';
 import { clearOfflineCache, readCache, writeCache } from './offline-cache';
+import { type PersistedSession, readPersistedSession } from './persisted-session';
 import { flush as flushAnalytics, setAnalyticsUser, track } from './analytics';
 import { resetConnectivity } from './connectivity';
 import { clearWidget } from './widget';
@@ -353,6 +359,22 @@ async function acquireAppleCredential(): Promise<{
 interface AuthState {
   /** The signed-in Firebase user, or null when signed out. */
   user: User | null;
+  /**
+   * The uid to route by: the real session's, or — before Firebase has answered
+   * — the one read off disk. See {@link AuthState.sessionPresumed}.
+   */
+  sessionUid: string | null;
+  /**
+   * True when {@link AuthState.sessionUid} came from disk rather than from
+   * Firebase, because `onAuthStateChanged` had not fired yet (#83).
+   *
+   * **Never treat this as authentication.** It says a session was persisted on
+   * this device, not that it is still valid. It exists only so the gate can
+   * stop holding a tap-eating splash over a working app while Firebase
+   * validates a token over a network that is not answering. It is discarded the
+   * moment the real event arrives, and that event wins whatever it says.
+   */
+  sessionPresumed: boolean;
   /** True until the first onAuthStateChanged fires (avoids a sign-in flash). */
   initializing: boolean;
   /** True when the user's custom claims grant Pro (Stripe `stripeRole:paid`
@@ -442,6 +464,11 @@ const AuthContext = createContext<AuthState | undefined>(undefined);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [initializing, setInitializing] = useState(true);
+  /** Set only if Firebase has not answered within {@link PRESUMED_SESSION_AFTER_MS}. */
+  const [presumed, setPresumed] = useState<PersistedSession | null>(null);
+  /** Whether the real auth event has landed. A ref, not state: the timer below
+   *  reads it at fire time and must not re-arm when it changes. */
+  const authAnswered = useRef(false);
   const [isPro, setIsPro] = useState(false);
   const [emailVerified, setEmailVerified] = useState(false);
   // Profile is keyed by uid so "loaded for the current user" is derivable
@@ -591,10 +618,41 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  // #83 — adopt the on-disk session if Firebase is too slow to answer.
+  //
+  // The grace period is the whole safety argument. Measured on the LG G6:
+  // `onAuthStateChanged` fires at ~771 ms on a working network and ~8,690 ms
+  // against black-holed DNS, because Firebase validates the restored token
+  // before it will emit and that call has no timeout we control. Waiting
+  // longer than a working network ever needs means the presumed session is
+  // adopted ONLY when the network is genuinely failing — which is also exactly
+  // when nothing else could have succeeded anyway. On a healthy launch this
+  // timer is cleared before it fires and the presumed path never runs at all.
   useEffect(() => {
-    console.log(`[GATE] authListenerAttached t=${Date.now() - GATE_T0}ms`);
+    let live = true;
+    const t = setTimeout(() => {
+      if (!live || authAnswered.current) return;
+      void readPersistedSession().then((session) => {
+        // Re-check: the disk read is async and Firebase may have answered
+        // during it. The real event always wins.
+        if (!live || authAnswered.current || !session) return;
+        setPresumed(session);
+        setInitializing(false);
+      });
+    }, PRESUMED_SESSION_AFTER_MS);
+    return () => {
+      live = false;
+      clearTimeout(t);
+    };
+  }, []);
+
+  useEffect(() => {
     return onAuthStateChanged(auth, (u) => {
-      console.log(`[GATE] onAuthStateChanged FIRED t=${Date.now() - GATE_T0}ms user=${u ? 'yes' : 'no'}`);
+      // The real answer has landed; the presumed session is now worthless
+      // whatever it said, including when `u` is null (a revoked or signed-out
+      // session must not keep routing as signed in).
+      authAnswered.current = true;
+      setPresumed(null);
       setUser(u);
       setEmailVerified(u?.emailVerified ?? false);
       // uid only — never the email (PII minimization). A uid resolves to a
@@ -627,7 +685,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // #79: measured on the LG G6 with wifi associated but no route to the
       // backend, the splash covered a fully-rendered screen for 30+ seconds and
       // swallowed every tap, with no feedback of any kind.
-      console.log(`[GATE] initializing=false t=${Date.now() - GATE_T0}ms`);
       setInitializing(false);
     });
   }, []);
@@ -686,6 +743,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    * condition.
    */
   const profileConfirmed = !!matchedProfile && matchedProfile.confirmed;
+
+  // The real session always wins; `presumed` is only ever non-null before the
+  // first auth event (#83), and is cleared by it.
+  const sessionUid = user?.uid ?? presumed?.uid ?? null;
+  const sessionPresumed = !user && presumed != null;
 
   /**
    * Runs the Microsoft OAuth dance and returns the Firebase credential.
@@ -747,12 +809,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const value = useMemo<AuthState>(
     () => ({
       user,
+      sessionUid,
+      sessionPresumed,
       initializing,
       isPro,
       profile,
       profileLoading,
       profileConfirmed,
-      emailVerified,
+      // Follows the presumed session too (#83), or a verified returning user
+      // gets bounced to /verify-email for the whole window.
+      emailVerified: user ? emailVerified : (presumed?.emailVerified ?? emailVerified),
       reloadUser: async () => {
         const u = auth.currentUser;
         if (!u) return false;
@@ -1019,12 +1085,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }),
     [
       user,
+      sessionUid,
+      sessionPresumed,
       initializing,
       isPro,
       profile,
       profileLoading,
       profileConfirmed,
       emailVerified,
+      presumed,
       googleAvailable,
       microsoftAvailable,
       msRequest,

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -52,6 +52,9 @@ import { LinkError, type LinkableProvider, type PendingLink } from './link-error
 export { LinkError } from './link-error';
 export type { LinkableProvider, PendingLink } from './link-error';
 import { auth, functions } from './firebase';
+
+/** TEMP instrumentation for #83 — removed before the fix ships. */
+export const GATE_T0 = Date.now();
 import { ensureProfile, subscribeProfile } from './ledger';
 import { registerAppleRefreshToken } from './appleSignin';
 import { addBreadcrumb, captureError, setSentryUser } from './sentry';
@@ -589,7 +592,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }
 
   useEffect(() => {
+    console.log(`[GATE] authListenerAttached t=${Date.now() - GATE_T0}ms`);
     return onAuthStateChanged(auth, (u) => {
+      console.log(`[GATE] onAuthStateChanged FIRED t=${Date.now() - GATE_T0}ms user=${u ? 'yes' : 'no'}`);
       setUser(u);
       setEmailVerified(u?.emailVerified ?? false);
       // uid only — never the email (PII minimization). A uid resolves to a
@@ -622,6 +627,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // #79: measured on the LG G6 with wifi associated but no route to the
       // backend, the splash covered a fully-rendered screen for 30+ seconds and
       // swallowed every tap, with no feedback of any kind.
+      console.log(`[GATE] initializing=false t=${Date.now() - GATE_T0}ms`);
       setInitializing(false);
     });
   }, []);

--- a/apps/mobile/src/lib/auth.tsx
+++ b/apps/mobile/src/lib/auth.tsx
@@ -469,6 +469,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   /** Whether the real auth event has landed. A ref, not state: the timer below
    *  reads it at fire time and must not re-arm when it changes. */
   const authAnswered = useRef(false);
+  /**
+   * The uid everything below keys on. Before Firebase answers this may be the
+   * session read off disk (#83); the real event clears `presumed` and this
+   * collapses back to `user.uid` (or null).
+   */
+  const sessionUid = user?.uid ?? presumed?.uid ?? null;
   const [isPro, setIsPro] = useState(false);
   const [emailVerified, setEmailVerified] = useState(false);
   // Profile is keyed by uid so "loaded for the current user" is derivable
@@ -695,7 +701,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   // `confirmed` records whether the SERVER has answered, and it is the field
   // the onboarding gate turns on — see `profileConfirmed` below.
   useEffect(() => {
-    const uid = user?.uid;
+    // `sessionUid`, not `user?.uid`: during a presumed session (#83) this is
+    // what lets `readCache` paint the profile from disk. Without it the gate
+    // sits at `assessRoute` -> 'wait' — the splash lifts off `initializing`
+    // and is immediately re-raised by the profile it never started loading,
+    // which is exactly the bug the first cut of this shipped with.
+    const uid = sessionUid;
     if (!uid) {
       setProfileEntry(null);
       return;
@@ -725,13 +736,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setProfileEntry({ uid, profile: null, confirmed: false });
       },
     );
-  }, [user?.uid]);
+  }, [sessionUid]);
 
   // Only trust the profile when it belongs to the current user; until then
   // the gate must treat it as still loading.
-  const matchedProfile = profileEntry && user && profileEntry.uid === user.uid ? profileEntry : null;
+  const matchedProfile =
+    profileEntry && sessionUid && profileEntry.uid === sessionUid ? profileEntry : null;
   const profile = matchedProfile ? matchedProfile.profile : null;
-  const profileLoading = !!user && !matchedProfile;
+  const profileLoading = !!sessionUid && !matchedProfile;
   /**
    * Whether the profile came from the SERVER, rather than from disk or from an
    * empty offline cache.
@@ -744,9 +756,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    */
   const profileConfirmed = !!matchedProfile && matchedProfile.confirmed;
 
-  // The real session always wins; `presumed` is only ever non-null before the
-  // first auth event (#83), and is cleared by it.
-  const sessionUid = user?.uid ?? presumed?.uid ?? null;
+  /** True while {@link sessionUid} came from disk rather than from Firebase. */
   const sessionPresumed = !user && presumed != null;
 
   /**

--- a/apps/mobile/src/lib/persisted-session.ts
+++ b/apps/mobile/src/lib/persisted-session.ts
@@ -1,0 +1,83 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+/**
+ * The last signed-in session, read straight off disk without waiting for
+ * Firebase Auth.
+ *
+ * ## Why this exists (#83)
+ *
+ * `onAuthStateChanged` does not fire until Firebase has validated the restored
+ * user's ID token, and that validation is a network call with no timeout we
+ * control. Measured on the LG G6 against a black-holed DNS: **8,690 ms** to the
+ * first auth event, against **771 ms** on a working network. Until it fires,
+ * `initializing` is true and the root layout holds a full-screen, tap-eating
+ * splash over the app — so a dead network costs nearly nine seconds of a screen
+ * that answers nothing.
+ *
+ * None of that wait buys information we do not already have. Firebase's own
+ * React Native persistence writes the session to `AsyncStorage` on every auth
+ * change, so the uid of the last signed-in user is sitting on disk and can be
+ * read in single-digit milliseconds. That is enough to answer the only question
+ * the gate is blocked on: *is there a session here at all, and whose?*
+ *
+ * ## What this is NOT
+ *
+ * **It is not authentication, and it must never be treated as such.** A record
+ * on disk proves someone signed in on this device once, not that the session is
+ * still valid — the token may be expired, revoked, or belong to a deleted
+ * account. Nothing here grants access to anything: every read and write still
+ * goes through `firestore.rules`, which sees the real Firebase session or no
+ * session at all. The presumed uid only decides which cached screen to paint
+ * while the real answer is in flight, and it is discarded the instant
+ * `onAuthStateChanged` fires — whatever that says wins, including "signed out".
+ */
+
+/** Firebase JS persists under `firebase:authUser:{apiKey}:{appName}`. */
+const AUTH_KEY_PREFIX = 'firebase:authUser:';
+
+export interface PersistedSession {
+  uid: string;
+  /** Mirrors `User.emailVerified`; the gate routes on it before Firebase answers. */
+  emailVerified: boolean;
+}
+
+/**
+ * Parse Firebase's persisted auth blob. Exported for tests — the shape is the
+ * SDK's, not ours, so it is worth pinning what we depend on: exactly two
+ * fields, both of which have been stable across the v9→v12 major versions.
+ */
+export function parsePersistedSession(raw: string | null): PersistedSession | null {
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    const uid = (parsed as Record<string, unknown>)['uid'];
+    if (typeof uid !== 'string' || uid.length === 0) return null;
+    // Absent means "not verified" rather than "unknown": treating a missing
+    // flag as verified would route an unverified signup straight into the app,
+    // where every write then fails the rules' email_verified gate.
+    return { uid, emailVerified: (parsed as Record<string, unknown>)['emailVerified'] === true };
+  } catch {
+    // A corrupt blob is not an error worth surfacing — it just means we wait
+    // for Firebase like we always did.
+    return null;
+  }
+}
+
+/**
+ * The persisted session, or null if there is none / it cannot be read.
+ *
+ * Never throws and never rejects: every failure mode here (no key, corrupt
+ * JSON, AsyncStorage unavailable) has the same correct answer — "we do not
+ * know, fall back to waiting for Firebase".
+ */
+export async function readPersistedSession(): Promise<PersistedSession | null> {
+  try {
+    const keys = await AsyncStorage.getAllKeys();
+    const key = keys.find((k) => k.startsWith(AUTH_KEY_PREFIX));
+    if (!key) return null;
+    return parsePersistedSession(await AsyncStorage.getItem(key));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #83

**Measured before building.** On the LG G6 against black-holed DNS, `onAuthStateChanged` fires at **8,690 ms**; on a working network, **771 ms**. Firebase validates the restored token before it will emit, and that call has no timeout we control. `initializing` gates a full-screen tap-eating splash on that event. The 8 s `GATE_MAX_WAIT_MS` from #79 fired at 16,734 ms and contributed nothing — the two waits are sequential, as suspected.

**A — adopt the on-disk session.** Firebase's own RN persistence writes the session to AsyncStorage, so the uid is readable in milliseconds. If Firebase hasn't answered within `PRESUMED_SESSION_AFTER_MS` (1200), adopt it: stop holding the splash, stop redirecting to `/sign-in`. The grace period is the safety argument — far past what a healthy launch needs, so the presumed path only runs when the network is genuinely failing.

It is **not authentication** and the module says so at length. A record on disk proves someone signed in here once, not that the session is valid. Nothing is granted: every read and write still goes through `firestore.rules`, which sees the real session or none. The real event always wins, including when it says signed out.

**B — the splash gets a voice.** Past 5 s it says "Still connecting…" in all three locales. No Retry button, deliberately: the only recovery is a restart, which doesn't help when the network is the cause, so the button would promise a fix it can't deliver. A covers returning users; B covers what A can't — a first launch with no persisted session and no network.

### Device-verified, both paths

| Black-holed DNS | Before #79 | After #79 | Now |
|---|---|---|---|
| Splash clears | >30 s | 10–15 s | **~6 s** (JS mounts ~4–5 s on this device) |

At 6 s the app is interactive with the presumed session (avatar reads "?"); by 12 s the real session has landed and corrected it (**"QT"**) with no splash flap-back — the #79 latch held. Happy path: interactive at 6 s showing "QT" throughout, so the presumed path never engaged, and full data by 9 s.

**One bug caught on device, not by tests:** the first cut lifted the splash off `initializing` and it was instantly re-raised, because with a presumed session the profile had never started loading and `assessRoute` returned `'wait'`. The profile subscription now keys on the session rather than the Firebase user. Also: a presumed session never routes to `/verify-email`, since that flag comes off a disk blob that can be stale.

`useCoreSnapshot` is deliberately untouched — nothing subscribes Firestore on a presumed uid from there.

11 new tests pin that every malformed persisted blob degrades to `null` (= "wait for Firebase like we always did"). 449/449 mobile, tsc clean, lint at its 56-error baseline.