### PR TITLE
fix(train): bound the load on a lifted set (#85)

### DIFF
--- a/apps/mobile/src/app/(app)/train.tsx
+++ b/apps/mobile/src/app/(app)/train.tsx
@@ -37,6 +37,7 @@ import {
   RIR_MIN,
   STARTER_TEMPLATES,
   clampRir,
+  clampSetLoad,
   seedTemplateName,
   setRowLabels,
   // Cardio (ADR-0025 / ADR-0026): the modality list the picker renders, the
@@ -1156,7 +1157,10 @@ function SetRow({
                 type: 'patchSet',
                 exerciseIndex,
                 setIndex,
-                patch: { weight: parseLoadToLb(t, unitSystem) ?? undefined },
+                // Through the shared ceiling (@macrolog/core) for the same
+                // reason RIR is: `parseLoadToLb` only converts units and
+                // rejects negatives, so a mistyped 12750 was storable (#85).
+                patch: { weight: clampSetLoad(parseLoadToLb(t, unitSystem)) },
               },
               { defer: true },
             );

--- a/packages/core/src/firestore-writers.ts
+++ b/packages/core/src/firestore-writers.ts
@@ -45,6 +45,7 @@ import type {
   SessionStatus,
   TemplateExercise,
 } from './workout';
+import { sanitizeSessionExercises } from './set-load-bounds';
 
 /**
  * The SDK values a doc needs that this module cannot construct. Each adapter
@@ -501,7 +502,10 @@ export function toSessionDoc<TS>(
   return {
     status: draft.status,
     timestamp: codec.timestamp(draft.date),
-    exercises: draft.exercises ?? [],
+    // Every session write on both frontends passes through here, which makes
+    // this the one place a corrupt set load can be stopped (#85) —
+    // `firestore.rules` cannot iterate a list and so never sees a set at all.
+    exercises: sanitizeSessionExercises(draft.exercises ?? []),
     createdAt: stamp,
     updatedAt: stamp,
     ...(draft.templateId !== undefined ? { templateId: draft.templateId } : {}),
@@ -534,7 +538,7 @@ export function toSessionPatch<TS>(
   if (patch.bodyweight !== undefined) data['bodyweight'] = patch.bodyweight;
   if (patch.sleepHours !== undefined) data['sleepHours'] = patch.sleepHours;
   if (patch.durationMin !== undefined) data['durationMin'] = patch.durationMin;
-  if (patch.exercises !== undefined) data['exercises'] = patch.exercises;
+  if (patch.exercises !== undefined) data['exercises'] = sanitizeSessionExercises(patch.exercises);
   // Like `exercises`, this is a whole-array overwrite rather than a merge:
   // Firestore unions arrays on merge, so a sparse patch would append blocks
   // instead of replacing them and a deleted block would come back.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,7 @@ export * from './weight-projection';
 // Bodyweight sanity rules (shared by both frontends — logger, workout-finish
 // mirror, store backstop). Distinct from ./macro-heuristic's CALC_WEIGHT_*
 // input range; see the header of ./weight-bounds.
+export * from './set-load-bounds';
 export * from './weight-bounds';
 // Body weight in the unit the user reads and types, over a store that is always
 // POUNDS. Display/input seam only — see the header for why the model never

--- a/packages/core/src/set-load-bounds.test.ts
+++ b/packages/core/src/set-load-bounds.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+import { type DocCodec, toSessionDoc, toSessionPatch } from './firestore-writers';
+import {
+  ADDED_LOAD_ABS_MAX_LB,
+  SET_LOAD_ABS_MAX_LB,
+  SET_LOAD_MAX_LB,
+  clampSetLoad,
+  isStorableSetLoad,
+  sanitizeSessionExercises,
+} from './set-load-bounds';
+import type { SessionExercise } from './workout';
+
+/**
+ * #85 — a live account stored `weight: 1275` on a set of BODYWEIGHT glute
+ * bridges. `firestore.rules` cannot iterate a list, so it never validates a
+ * set at all and there is no server-side fallback for this class.
+ */
+
+/** Mirrors the stand-in in `firestore-writers.test.ts` — plain, comparable
+ *  values so a test can assert on the emitted doc directly. */
+const codec: DocCodec<{ ts: number }> = {
+  timestamp: (d) => ({ ts: d.getTime() }),
+  remove: () => '<delete>',
+};
+
+const NOW = new Date(2026, 7, 25, 9, 0);
+
+function ex(sets: SessionExercise['sets'], logStyle?: SessionExercise['logStyle']): SessionExercise {
+  return { exerciseId: 'e1', name: 'Glute Bridge', cues: [], sets, ...(logStyle ? { logStyle } : {}) };
+}
+
+describe('clampSetLoad', () => {
+  it('accepts an ordinary load', () => {
+    expect(clampSetLoad(135)).toBe(135);
+    expect(clampSetLoad('47.5')).toBe(47.5);
+  });
+
+  it('keeps ZERO — an empty bar is a real load', () => {
+    // The guard that matters: `Number('')` is also 0, so emptiness must be
+    // checked before coercion or clearing the field would record a 0 lb set.
+    expect(clampSetLoad(0)).toBe(0);
+    expect(clampSetLoad('')).toBeUndefined();
+    expect(clampSetLoad(null)).toBeUndefined();
+    expect(clampSetLoad(undefined)).toBeUndefined();
+  });
+
+  it('rejects a typo rather than clamping it down', () => {
+    // Unlike RIR, where "very easy" made a clamp the unambiguous intent,
+    // nobody who typed 12750 meant the ceiling.
+    expect(clampSetLoad(12750)).toBeUndefined();
+    expect(clampSetLoad(SET_LOAD_MAX_LB + 1)).toBeUndefined();
+    expect(clampSetLoad(SET_LOAD_MAX_LB)).toBe(SET_LOAD_MAX_LB);
+  });
+
+  it('rejects negatives and nonsense', () => {
+    expect(clampSetLoad(-5)).toBeUndefined();
+    expect(clampSetLoad('heavy')).toBeUndefined();
+    expect(clampSetLoad(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(clampSetLoad(Number.NaN)).toBeUndefined();
+  });
+});
+
+describe('isStorableSetLoad — the wider backstop', () => {
+  it('is wider than the input ceiling, on purpose', () => {
+    // Same split as ./weight-bounds: a genuine load near the soft ceiling must
+    // still save down a path that did not go through the input.
+    expect(SET_LOAD_ABS_MAX_LB).toBeGreaterThan(SET_LOAD_MAX_LB);
+    expect(isStorableSetLoad(SET_LOAD_MAX_LB + 100)).toBe(true);
+    expect(isStorableSetLoad(SET_LOAD_ABS_MAX_LB + 1)).toBe(false);
+  });
+});
+
+describe('sanitizeSessionExercises', () => {
+  it('drops a load no lift could produce', () => {
+    const out = sanitizeSessionExercises([ex([{ kind: 'working', reps: 10, weight: 99999 }])]);
+    expect(out[0].sets[0]).toEqual({ kind: 'working', reps: 10 });
+  });
+
+  it('drops the FIELD rather than zeroing it', () => {
+    // 0 is a real load, so writing 0 would replace "corrupt" with "lifted
+    // nothing" — data instead of absence.
+    const out = sanitizeSessionExercises([ex([{ kind: 'working', reps: 10, weight: 99999 }])]);
+    expect('weight' in out[0].sets[0]).toBe(false);
+  });
+
+  it('returns the SAME ARRAY when nothing needed fixing', () => {
+    // Identity matters: a copy on every save rewrites the whole doc.
+    const input = [ex([{ kind: 'working', reps: 10, weight: 135 }])];
+    expect(sanitizeSessionExercises(input)).toBe(input);
+  });
+
+  it('does not copy exercises that were already clean', () => {
+    const clean = ex([{ kind: 'working', reps: 8, weight: 100 }]);
+    const dirty = ex([{ kind: 'working', reps: 8, weight: 99999 }]);
+    const out = sanitizeSessionExercises([clean, dirty]);
+    expect(out[0]).toBe(clean);
+    expect(out[1]).not.toBe(dirty);
+  });
+
+  it('keeps a plausible ADDED load on a bodyweight exercise', () => {
+    // The reported account's other glute-bridge sets carry 12 lb, which is a
+    // held dumbbell. Stripping those would delete real work.
+    const out = sanitizeSessionExercises([ex([{ kind: 'working', reps: 10, weight: 12 }], 'bodyweight')]);
+    expect(out[0].sets[0].weight).toBe(12);
+  });
+
+  /**
+   * The bound follows the movement. This is the pair that a single global
+   * ceiling could not express, and the reason #85 needed two numbers.
+   */
+  describe('the reported defect: 1,275 lb', () => {
+    const bad = [{ kind: 'working' as const, reps: 10, weight: 1275 }];
+
+    it('is REJECTED on a bodyweight exercise — nobody hangs that off a belt', () => {
+      const out = sanitizeSessionExercises([ex(bad, 'bodyweight')]);
+      expect('weight' in out[0].sets[0]).toBe(false);
+      expect(1275).toBeGreaterThan(ADDED_LOAD_ABS_MAX_LB);
+    });
+
+    it('is KEPT on a weight-reps exercise — that is a loaded leg press', () => {
+      const out = sanitizeSessionExercises([ex(bad, 'weight-reps')]);
+      expect(out[0].sets[0].weight).toBe(1275);
+    });
+
+    it('treats a missing logStyle as weight-reps, the documented default', () => {
+      expect(sanitizeSessionExercises([ex(bad)])[0].sets[0].weight).toBe(1275);
+    });
+  });
+});
+
+describe('the write seam', () => {
+  const dirty = [ex([{ kind: 'working', reps: 10, weight: 99999 }])];
+
+  it('sanitizes through toSessionDoc', () => {
+    const doc = toSessionDoc({ status: 'completed', date: NOW, exercises: dirty }, codec, NOW);
+    expect(doc.exercises[0].sets[0]).toEqual({ kind: 'working', reps: 10 });
+  });
+
+  it('sanitizes through toSessionPatch — the live logger writes through this one', () => {
+    const patch = toSessionPatch({ exercises: dirty }, codec, NOW);
+    expect((patch['exercises'] as SessionExercise[])[0].sets[0]).toEqual({ kind: 'working', reps: 10 });
+  });
+
+  it('leaves a template alone — templates carry plannedSets, not sets', () => {
+    // Guards the mistake made while wiring this: `exercises: draft.exercises`
+    // appears in BOTH the template and session writers.
+    const doc = toSessionDoc({ status: 'active', date: NOW }, codec, NOW);
+    expect(doc.exercises).toEqual([]);
+  });
+});

--- a/packages/core/src/set-load-bounds.ts
+++ b/packages/core/src/set-load-bounds.ts
@@ -1,0 +1,138 @@
+import type { SessionExercise, WorkoutSet } from './workout';
+
+/**
+ * Sanity rules for the load on a lifted set — the one place, shared by both
+ * frontends, that answers "is this a plausible weight to have lifted".
+ *
+ * ## Why this exists (#85)
+ *
+ * A live account stored `weight: 1275` on a set of **bodyweight glute
+ * bridges**. Nothing rejected it, and nothing could have: `firestore.rules`
+ * validates `exercises is list && size() <= 40` and nothing inside, because
+ * rules have no way to iterate a list. That is the same reason {@link
+ * clampRir} had to exist after a set was found stored with `rir: 8`. There is
+ * no server-side fallback for this class; it has to be caught on the client.
+ *
+ * Modelled on `./weight-bounds`, including the deliberate split between a soft
+ * range enforced at the input and a wider absolute backstop enforced on write,
+ * so a genuine edge-case load still saves while obvious garbage cannot persist
+ * down any path — logger, template, or import.
+ *
+ * ## The bound follows the MOVEMENT, and that is the whole idea
+ *
+ * A single ceiling cannot catch the reported defect. 1,275 lb is absurd for a
+ * glute bridge and unremarkable for a loaded leg press, and no one threshold
+ * separates them — so there are two. A `weight-reps` exercise gets
+ * {@link SET_LOAD_ABS_MAX_LB}, which only has to catch an extra digit. A
+ * `bodyweight` exercise gets {@link ADDED_LOAD_ABS_MAX_LB}, because a load
+ * there is a held dumbbell, a belt or a vest rather than a barbell, and that
+ * is bounded an order of magnitude lower.
+ *
+ * That split is what makes 1,275 lb on a glute bridge rejectable while the
+ * same account's plausible 12 lb on the same exercise survives — and it is
+ * why the numeric bounds alone were not enough.
+ */
+
+/**
+ * Soft ceiling, enforced at the input: a hard reject above this.
+ *
+ * Sized against this app's population rather than against powerlifting
+ * records. Ignia's users log 5 lb dumbbells and 40 lb pin stacks; the heaviest
+ * plausible entry is a loaded leg press or hack squat, which reaches a few
+ * hundred pounds well short of this. A four-digit entry is far more often a
+ * typo than a lift.
+ */
+export const SET_LOAD_MAX_LB = 1000;
+
+/**
+ * Absolute backstop enforced on write, wider than the input range for the same
+ * reason `WEIGHT_ABS_MAX_LB` is: a genuine load near the soft ceiling must
+ * still save, while a value that could only be corrupt must not persist
+ * whatever wrote it.
+ */
+export const SET_LOAD_ABS_MAX_LB = 1500;
+
+/**
+ * Ceiling for ADDED load on a `bodyweight`-logged exercise.
+ *
+ * A load here is real — a dumbbell held during a glute bridge, a belt on a
+ * pull-up, a weighted vest — so it is kept rather than stripped: deleting real
+ * logged work to fix a different bug is the one outcome worth being
+ * conservative about, and the reported account's own 12 lb entries are exactly
+ * that case.
+ *
+ * But it is bounded far lower than a barbell lift, because nobody hangs 1,275
+ * lb off a belt. This is the bound that actually catches #85.
+ */
+export const ADDED_LOAD_ABS_MAX_LB = 200;
+
+/**
+ * Coerce user input to a storable set load, or `undefined` to leave it unset.
+ *
+ * Deliberately the same shape and the same guards as {@link clampRir} in
+ * `./workout`: emptiness is checked BEFORE coercion, because `Number('')` and
+ * `Number(null)` are both `0` and a 0 lb set is meaningful (an unloaded bar,
+ * an empty machine). Values above the ceiling become `undefined` rather than
+ * clamping down to it — unlike RIR, where "very easy" made a clamp the
+ * unambiguous intent, nobody who typed 12750 meant 1000.
+ */
+export function clampSetLoad(value: unknown): number | undefined {
+  if (value == null || value === '') return undefined;
+  const n = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(n) || n < 0 || n > SET_LOAD_MAX_LB) return undefined;
+  return n;
+}
+
+/** True when a load is within the absolute range the store will persist. */
+export function isStorableSetLoad(weight: number): boolean {
+  return Number.isFinite(weight) && weight >= 0 && weight <= SET_LOAD_ABS_MAX_LB;
+}
+
+/** The store-seam ceiling for a set, which depends on how it is logged. */
+export function maxStorableLoadFor(logStyle: SessionExercise['logStyle']): number {
+  return logStyle === 'bodyweight' ? ADDED_LOAD_ABS_MAX_LB : SET_LOAD_ABS_MAX_LB;
+}
+
+function sanitizeSet(set: WorkoutSet, logStyle: SessionExercise['logStyle']): WorkoutSet {
+  if (set.weight === undefined) return set;
+  const ok =
+    Number.isFinite(set.weight) && set.weight >= 0 && set.weight <= maxStorableLoadFor(logStyle);
+  if (!ok) {
+    // Drop the field rather than zero it: 0 is a real load (an empty bar), so
+    // writing 0 would replace "corrupt" with "lifted nothing", which reads as
+    // data rather than as absence.
+    const { weight: _dropped, ...rest } = set;
+    return rest;
+  }
+  return set;
+}
+
+/**
+ * Drop any set load that could only be corrupt, on every write path.
+ *
+ * Applied in `toSessionDoc`/`toSessionPatch`, which both write `exercises`
+ * wholesale and are the single seam every session write on both frontends
+ * passes through — the analogue of the store-seam clamp `./weight-bounds`
+ * describes for bodyweight.
+ *
+ * Returns the input array unchanged (by identity) when nothing needed
+ * sanitizing, so the common path allocates nothing and a session doc does not
+ * rewrite itself on every save.
+ */
+export function sanitizeSessionExercises(exercises: SessionExercise[]): SessionExercise[] {
+  let anyChanged = false;
+  const next = exercises.map((ex) => {
+    // Tracked PER EXERCISE: a shared flag would copy every exercise after the
+    // first dirty one, so a single bad set would rewrite the whole array.
+    let exChanged = false;
+    const sets = ex.sets.map((s) => {
+      const clean = sanitizeSet(s, ex.logStyle);
+      if (clean !== s) exChanged = true;
+      return clean;
+    });
+    if (!exChanged) return ex;
+    anyChanged = true;
+    return { ...ex, sets };
+  });
+  return anyChanged ? next : exercises;
+}


### PR DESCRIPTION
Closes #85

A live account stored `weight: 1275` on a set of **bodyweight** glute bridges. Nothing rejected it and nothing could: `firestore.rules` validates `exercises is list && size() <= 40` and nothing inside, because rules cannot iterate a list. Same reason `clampRir` had to exist after a `rir: 8` turned up — **there is no server-side fallback for this class.**

### The bound follows the movement

A single ceiling cannot separate "1,275 lb glute bridge" from "1,275 lb leg press", so there are two:

| logStyle | Store ceiling | Why |
|---|---|---|
| `weight-reps` | **1,500 lb** | only has to catch an extra digit |
| `bodyweight` | **200 lb** | a load here is a held dumbbell, a belt, a vest — not a barbell |

That split is what makes the reported 1,275 rejectable while the same account's plausible **12 lb** on the same exercise survives. I built this with a single global ceiling first and it did **not** catch the defect that opened the issue — worth knowing before anyone simplifies it back.

**Added load is kept, not stripped.** Deleting real logged work to fix a different bug is the outcome worth being conservative about.

### Two seams, mirroring `weight-bounds.ts`

- **`clampSetLoad`** at the input (mobile logger), soft ceiling 1,000. Rejects a typo rather than clamping down — unlike RIR, where "very easy" made a clamp the unambiguous intent, nobody who typed 12750 meant 1000. Zero survives, because an empty bar is a real load and `Number('')` is also `0`.
- **`sanitizeSessionExercises`** in `toSessionDoc`/`toSessionPatch`, which write `exercises` wholesale and are the one seam every session write on **both** frontends passes through. Returns the input array by identity when nothing needed fixing, so a clean doc doesn't rewrite itself on every save.

Bounds sized against this app's users — 5 lb dumbbells, 40 lb pin stacks — not against powerlifting records.

**One trap hit while wiring it:** `exercises: draft.exercises ?? []` appears in *both* the template and session writers, and my first edit patched the template one (templates carry `plannedSets`, not `sets`). There's a test pinning that.

core 1249 · mobile 449 · web 206 · tsc clean · lint at its 56-error baseline. JS-only → ships by OTA.