### PR TITLE
feat(health): answer ADR-0030 Q5 and finish step 3 — ratchet to 0 (#77)

### DIFF
--- a/apps/mobile/src/__tests__/health-import-day-boundary.test.ts
+++ b/apps/mobile/src/__tests__/health-import-day-boundary.test.ts
@@ -1,0 +1,73 @@
+import { MIDNIGHT, type DayBoundary, dayKeyAt } from '@macrolog/core';
+
+/**
+ * ADR-0030 Q5 — which imported records move with the user's day boundary, and
+ * which keep their source's day.
+ *
+ * The rule is one sentence and the consequences are not obvious, so they are
+ * pinned here rather than left to the comments at each call site:
+ *
+ *   **We derive the day only when the source did not.**
+ *
+ * A raw sample carries an instant and no day, so the day is ours and the
+ * boundary applies. An OS-bucketed daily TOTAL already has a day — the OS made
+ * it, at calendar midnight, over a full 00:00–24:00 window — so re-keying it
+ * would file a whole calendar day's steps as the previous user-day. Sleep is a
+ * third case: it keeps the wake-day rule ADR-0033 owns.
+ *
+ * `scripts/check-day-boundary.mjs` enforces the same split mechanically, by
+ * argument, in `CALENDAR_OK`. These tests state WHY.
+ */
+
+/** Days start at 03:00 from 2026-01-01 on. */
+const THREE_AM: DayBoundary = [{ from: '2026-01-01' as never, hour: 3 }];
+
+/** 01:30 on Wednesday the 12th — before a 3 AM day starts, so still TUESDAY. */
+const LATE_NIGHT = new Date(2026, 7, 12, 1, 30);
+
+describe('a raw sample takes the USER day', () => {
+  it('files a 01:30 weigh-in on the previous day under a 3 AM boundary', () => {
+    // `health.ts` calls exactly this for the raw weight/water/quantity paths.
+    expect(dayKeyAt(LATE_NIGHT, THREE_AM)).toBe('2026-08-11');
+  });
+
+  it('is unchanged for everyone on the default boundary', () => {
+    // MIDNIGHT is what every account has until they open the setting, and
+    // under it `dayKeyAt` IS the calendar date — so nothing moved for anyone.
+    expect(dayKeyAt(LATE_NIGHT, MIDNIGHT)).toBe('2026-08-12');
+  });
+});
+
+describe('an OS-bucketed daily total keeps its SOURCE day', () => {
+  it('would be mis-filed by a whole day if it took the user day', () => {
+    // The bucket starts at calendar midnight and holds 00:00-24:00 of steps.
+    const bucketStart = new Date(2026, 7, 12, 0, 0);
+    // What the importer stores (calendar), versus what converting would give.
+    expect(dayKeyAt(bucketStart, MIDNIGHT)).toBe('2026-08-12');
+    expect(dayKeyAt(bucketStart, THREE_AM)).toBe('2026-08-11');
+    // The second is the bug: a full Wednesday of steps filed under Tuesday.
+    // That is why `start` is exempted rather than converted.
+  });
+});
+
+describe('the cardio merge keys must move TOGETHER', () => {
+  /**
+   * `writeImportedBlocks` matches an imported block's day against the day of a
+   * session the user already logged, to decide whether to fold or to write a
+   * new one. Converting one side and not the other is worse than converting
+   * neither — it stops a late-night run finding its own session.
+   */
+  it('a 01:30 run and a 01:30 session agree under either boundary', () => {
+    const sessionDate = new Date(2026, 7, 12, 1, 30);
+    const blockStart = new Date(2026, 7, 12, 1, 45);
+    for (const b of [MIDNIGHT, THREE_AM]) {
+      expect(dayKeyAt(sessionDate, b)).toBe(dayKeyAt(blockStart, b));
+    }
+  });
+
+  it('and they would DISAGREE if only one had been converted', () => {
+    // The failure the coupling prevents, stated as a fact rather than a warning.
+    const sessionDate = new Date(2026, 7, 12, 1, 30);
+    expect(dayKeyAt(sessionDate, THREE_AM)).not.toBe(dayKeyAt(sessionDate, MIDNIGHT));
+  });
+});

--- a/apps/mobile/src/lib/health-sync.ts
+++ b/apps/mobile/src/lib/health-sync.ts
@@ -7,6 +7,7 @@ import {
   importableWorkouts,
   isLoggedCardioBlock,
   calendarDateKey,
+  dayKeyAt,
   latestSampleEndByDay,
   mergeImportedBlocks,
   parseYmd,
@@ -217,7 +218,7 @@ async function importScalars(uid: string): Promise<number> {
     ]);
     let applied = 0;
     for (const kind of IMPORT_KINDS) {
-      const samples = await health.readSamples(kind, IMPORT_DAYS);
+      const samples = await health.readSamples(kind, IMPORT_DAYS, boundary);
       const reduced = reduceImportedSamples(samples);
       // `reduceImportedSamples` folds sleep by SUM and throws the sample times
       // away with it. The wake instant is not part of the value and is not
@@ -302,10 +303,17 @@ export function toImportableBlocks(raw: readonly HealthWorkout[]): CardioBlock[]
 export async function writeImportedBlocks(uid: string, blocks: CardioBlock[]): Promise<number> {
   if (!blocks.length) return 0;
 
+  // ADR-0030 Q5. These two keys are MATCHED AGAINST EACH OTHER to decide
+  // whether an imported run folds into a session the user already logged, so
+  // they move together or not at all — converting one and not the other would
+  // stop a 00:30 run finding the session it belongs to and write a duplicate
+  // day instead. That coupling is why this was left until the decision existed.
+  const boundary = await getDayBoundaryOnce(uid);
+
   const sessions = await getRecentSessions(uid, SESSION_SCAN_LIMIT);
   const byDay = new Map<string, WorkoutSession>();
   for (const s of sessions) {
-    const key = calendarDateKey(s.date);
+    const key = dayKeyAt(s.date, boundary);
     // Sessions come back newest-first; keep the newest per day.
     if (!byDay.has(key)) byDay.set(key, s);
   }
@@ -313,7 +321,7 @@ export async function writeImportedBlocks(uid: string, blocks: CardioBlock[]): P
   // Group by day first so two runs on one day become one write, not two.
   const perDay = new Map<string, CardioBlock[]>();
   for (const b of blocks) {
-    const key = calendarDateKey(b.startedAt ?? new Date());
+    const key = dayKeyAt(b.startedAt ?? new Date(), boundary);
     const list = perDay.get(key);
     if (list) list.push(b);
     else perDay.set(key, [b]);

--- a/apps/mobile/src/lib/health.ts
+++ b/apps/mobile/src/lib/health.ts
@@ -8,7 +8,9 @@ import {
   flOzToLiters,
   kgToLb,
   litersToFlOz,
+  type DayBoundary,
   calendarDateKey,
+  dayKeyAt,
   parseYmd,
   percentToFraction,
 } from '@macrolog/core';
@@ -63,8 +65,21 @@ export interface HealthPort {
   isAvailable(): Promise<boolean>;
   /** Prompt for the read+write scopes we use. Resolves false if declined. */
   requestPermissions(): Promise<boolean>;
-  /** Read the last `sinceDays` of one kind as canonical-unit samples. */
-  readSamples(kind: ReadableKind, sinceDays: number): Promise<HealthSample[]>;
+  /**
+   * Read the last `sinceDays` of one kind as canonical-unit samples.
+   *
+   * `boundary` is the account's day boundary (ADR-0030 Q5). The OS hands back
+   * timestamped samples with no day of their own, so WE decide which day each
+   * belongs to — which makes this one of the derivations ADR-0030 governs. The
+   * two exceptions are documented at their call sites: an OS-bucketed daily
+   * TOTAL keeps the source's day, and sleep keeps the wake-day rule ADR-0033
+   * owns.
+   */
+  readSamples(
+    kind: ReadableKind,
+    sinceDays: number,
+    boundary: DayBoundary,
+  ): Promise<HealthSample[]>;
   /**
    * Read the last `sinceDays` of WORKOUTS as neutral events (ADR-0026).
    *
@@ -230,7 +245,7 @@ const healthKit: HealthPort = {
     });
   },
 
-  async readSamples(kind, sinceDays) {
+  async readSamples(kind, sinceDays, boundary) {
     const HK = await hkModule();
     const filter = { startDate: sinceDate(sinceDays), endDate: new Date() };
     const mine = (s: HKQty) => s.sourceRevision?.source?.bundleIdentifier === APP_ID;
@@ -243,6 +258,10 @@ const healthKit: HealthPort = {
       return rows
         .filter((s) => HK_ASLEEP.has(s.value))
         .map((s) => ({
+          // Sleep keeps the WAKE-DAY rule, which ADR-0033 owns and #80's guard
+          // depends on — a night belongs to the morning you got up, not to the
+          // user-day the boundary would put its end in. ADR-0030 deliberately
+          // does not reach in here.
           dateKey: calendarDateKey(new Date(s.endDate)),
           kind: 'sleep' as const,
           value: (ms(s.endDate) - ms(s.startDate)) / 3_600_000, // ms → hours
@@ -283,6 +302,12 @@ const healthKit: HealthPort = {
             // Key the day the bucket STARTS: a [midnight, next-midnight)
             // interval ends at the *following* day's 00:00, so keying off the
             // end — as the raw-sample path does — shifts every day forward one.
+            //
+            // And it stays the CALENDAR date under ADR-0030 Q5: the OS did this
+            // bucketing, at calendar midnight, and the bucket holds a full
+            // 00:00-24:00 total. Re-keying its start under a 03:00 boundary
+            // would file a whole calendar day's steps as the previous
+            // user-day — an imported daily TOTAL keeps its source's day.
             dateKey: calendarDateKey(start),
             kind,
             value: q,
@@ -300,7 +325,9 @@ const healthKit: HealthPort = {
       filter,
     } as never)) as unknown as HKQty[];
     return rows.map((s) => ({
-      dateKey: calendarDateKey(new Date(s.endDate ?? s.startDate)),
+      // A raw sample carries an instant and no day, so the day is OURS to
+      // derive — ADR-0030 Q5.
+      dateKey: dayKeyAt(new Date(s.endDate ?? s.startDate), boundary),
       kind,
       value: s.quantity,
       endMs: ms(s.endDate ?? s.startDate),
@@ -547,7 +574,7 @@ const healthConnect: HealthPort = {
     return Array.isArray(granted) ? granted.length > 0 : !!granted;
   },
 
-  async readSamples(kind, sinceDays) {
+  async readSamples(kind, sinceDays, boundary) {
     const HC = await hcModule();
     await HC.initialize();
 
@@ -584,7 +611,9 @@ const healthConnect: HealthPort = {
         const start = new Date(g.startTime ?? 0);
         return [
           {
-            // Key the day the bucket STARTS — see the iOS branch.
+            // Key the day the bucket STARTS, and keep the CALENDAR date — see
+            // the iOS branch for both halves. An OS-bucketed daily total keeps
+            // its source's day (ADR-0030 Q5).
             dateKey: calendarDateKey(start),
             kind,
             value,
@@ -612,6 +641,7 @@ const healthConnect: HealthPort = {
         const start = new Date(r.startTime ?? 0).getTime();
         const end = new Date(r.endTime ?? 0).getTime();
         return {
+          // Wake-day rule, owned by ADR-0033 — see the iOS sleep branch.
           dateKey: calendarDateKey(new Date(end)),
           kind: 'sleep' as const,
           value: (end - start) / 3_600_000,
@@ -624,7 +654,8 @@ const healthConnect: HealthPort = {
       return rows.map((r) => {
         const end = new Date(r.endTime ?? r.startTime ?? 0).getTime();
         return {
-          dateKey: calendarDateKey(new Date(end)),
+          // Raw sample, so the day is ours to derive — ADR-0030 Q5.
+          dateKey: dayKeyAt(new Date(end), boundary),
           kind: 'water' as const,
           value: litersToFlOz(r.volume?.inLiters ?? 0),
           endMs: end,
@@ -636,7 +667,8 @@ const healthConnect: HealthPort = {
     return rows.map((r) => {
       const t = new Date(r.time ?? 0).getTime();
       const lb = r.weight?.inPounds ?? (r.weight?.inKilograms != null ? kgToLb(r.weight.inKilograms) : 0);
-      return { dateKey: calendarDateKey(new Date(t)), kind: 'weight' as const, value: lb, endMs: t, fromUs: mine(r) };
+      // Raw sample, so the day is ours to derive — ADR-0030 Q5.
+      return { dateKey: dayKeyAt(new Date(t), boundary), kind: 'weight' as const, value: lb, endMs: t, fromUs: mine(r) };
     });
   },
 

--- a/docs/adr/0030-configurable-day-boundary.md
+++ b/docs/adr/0030-configurable-day-boundary.md
@@ -1,6 +1,6 @@
 # ADR-0030: When does a day start?
 
-- **Status:** **IMPLEMENTED and shipped (2026-08-25)** — Android OTA 52 (vc 37) and iOS OTA 26 (build 60, the PUBLIC App Store). All four steps are done: the derivation, the codemod, persistence, and the setting. **Open: Q4 (widget/watch) and Q5 (importers)** — decisions, not code; `npm run check:day-boundary` pins the 12 call sites blocked on them. See Amendments 1–3.
+- **Status:** **ACCEPTED — complete (2026-08-25).** All four steps shipped (Android OTA 52 / iOS OTA 26), and **both remaining questions are now answered**: Q4 (widget/watch) in `9c6d8efd`, Q5 (importers) in Amendment 5. `npm run check:day-boundary` is at **BASELINE 0** — every `calendarDateKey` left outside `packages/core` is exempted by argument with its reason. See Amendments 1–5.
 - **Date:** 2026-08-24
 - **Touches:** every `dateKey` derivation, the TDEE estimator, fasting, the Health/Oura importers, the widget and the watch
 
@@ -324,3 +324,56 @@ permanently, and indistinguishably from a broken integration.
 Q5's *conversion* work is still open: `npm run check:day-boundary` reports **10
 calls in 3 files**, unchanged by this fix, because nothing here converts an
 importer's `calendarDateKey`.
+
+## Amendment 5 — Q5 answered, and step 3 is finished (2026-08-25)
+
+The ratchet is at **0**. Q4 shipped earlier the same day; this closes Q5, and
+with it ADR-0030 itself.
+
+### The rule, in one sentence
+
+**We derive the day only when the source did not.**
+
+That is what separates the importer sites, which had looked like one class and
+are three:
+
+| Site | Decision | Why |
+|---|---|---|
+| Raw quantity samples — weight, water (iOS + Android) | **Converted** to `dayKeyAt` | A sample carries an instant and no day. The day is ours to choose, which is exactly what this ADR governs. |
+| OS-bucketed daily totals — steps, active energy | **Keep the calendar date** | The OS made the bucket, at calendar midnight, over a full 00:00–24:00 window. Re-keying its start under a 03:00 boundary would file a whole calendar day's steps as the *previous* user-day. An imported daily total keeps its **source's** day. |
+| Sleep (iOS + Android) | **Keep the wake-day rule** | A night belongs to the morning you woke. That is ADR-0033's rule and what #80's guard depends on; ADR-0030 deliberately does not reach into it. |
+
+The first two live a few lines apart in the same function, which is why "the
+importers" was never a single answer.
+
+### The coupling that made this wait
+
+`writeImportedBlocks` matches an imported block's day **against the day of a
+session the user already logged**, to decide whether to fold the run in or write
+a new one. Converting one side and not the other is worse than converting
+neither — a 00:30 run would stop finding its own session and silently write a
+duplicate day. Both moved in the same commit, and
+`health-import-day-boundary.test.ts` asserts they agree under both boundaries
+*and* that they would disagree if only one had moved.
+
+### Q4, for the record
+
+`widgets/render.tsx` still calls `calendarDateKey`, and that is correct. It is
+the **fallback** for snapshots written before `dayEndsMs` existed; `widgetView`
+prefers that field, which the phone computes with the user's boundary. Neither
+the Android widget nor `Glance.swift` re-derives a day — the app ships the
+answer. So Q4's answer is *"the native surfaces receive the boundary"*, not
+*"they are pinned to midnight"*.
+
+### What the ratchet means now
+
+`BASELINE = 0`. It still fails in **both** directions: a new unexempted site is
+a latent bug, and there is nothing left to convert, so a drop would mean the
+check itself broke. The exemption list is keyed by **argument text** with a
+reason per entry — a line number goes stale, and a whole-file exemption would
+hide the next call added to that file.
+
+### Nothing moved for any existing account
+
+Every account is on `MIDNIGHT`, under which `dayKeyAt` **is** the calendar date.
+The conversions are inert until someone opens Settings → *Day starts at*.

--- a/scripts/check-day-boundary.mjs
+++ b/scripts/check-day-boundary.mjs
@@ -15,20 +15,17 @@
  *    (`parseYmd`, or `addDays` off one). Applied to `new Date()`, a log's
  *    `.date`, or a health sample's `.endDate`, the right answer is `dayKeyAt`.
  *
- * The second is down to the sites blocked on ADR-0030's two OPEN DECISIONS, and
- * cannot go lower until they are answered:
+ * **Both of ADR-0030's open decisions are now answered and the count is ZERO.**
+ * Q4 (widget/watch) shipped in `9c6d8efd`; Q5 (importers) in the change that
+ * dropped this baseline. Every remaining `calendarDateKey` outside core is
+ * exempted BY ARGUMENT in `CALENDAR_OK` below, each with the reason it is
+ * genuinely not a user-day derivation.
  *
- *   - **Q4 (widget/watch)** — `widgets/render.tsx` and `useWidgetSync` render
- *     with no profile in scope, so answering Q4 decides whether they convert.
- *   - **Q5 (importers keep their source's day)** — `health.ts` / `health-sync.ts`.
- *     Converting HALF an importer is worse than converting none: the user's own
- *     session day and the imported block's day are matched against each other
- *     to merge, so moving one and not the other breaks the merge outright.
- *
- * So it is a **ratchet**: the count is pinned at `BASELINE` and the check fails
+ * It stays a **ratchet**: the count is pinned at `BASELINE` and the check fails
  * if it moves in EITHER direction. Up means a new latent bug. Down means a
  * conversion landed and the baseline was not tightened, which is how a ratchet
- * quietly stops being one.
+ * quietly stops being one. At zero the first half is what does the work — any
+ * new site must justify itself in `CALENDAR_OK` or convert.
  *
  * `--list` prints the outstanding sites.
  *
@@ -52,9 +49,30 @@ const CALENDAR_OK = {
   // `start` is `parseYmd(from)` — a settled key stepped by whole days. The
   // window's anchor is chosen inside `activityWindowRange`, which is threaded.
   'apps/mobile/src/lib/activity-suggestion.ts': ['addDays(start, i)'],
-  // Not a day bucket: the local-naive `YYYY-MM-DDTHH:mm:ss` string Health
-  // Connect's period slicer wants. Re-bucketing it would corrupt the request.
-  'apps/mobile/src/lib/health.ts': ['d'],
+  // ADR-0030 Q5, ANSWERED — these four are the importer sites, and they are
+  // exempt for two different reasons.
+  //
+  //   `d`      — not a day bucket at all: the local-naive
+  //              `YYYY-MM-DDTHH:mm:ss` string Health Connect's period slicer
+  //              wants. Re-bucketing it would corrupt the request.
+  //   `start`  — an OS-BUCKETED DAILY TOTAL (both platforms). The OS did this
+  //              bucketing, at calendar midnight, and the bucket holds a full
+  //              00:00-24:00 figure. Re-keying its start under a 03:00
+  //              boundary would file a whole calendar day's steps as the
+  //              previous user-day. Q5's rule: an imported daily total keeps
+  //              its SOURCE's day. The raw-sample paths beside these, which
+  //              carry an instant and no day, DID convert.
+  //   `new Date(s.endDate)` / `new Date(end)`
+  //            — SLEEP, on iOS and Android. A night belongs to the morning you
+  //              woke, which is ADR-0033's rule and what #80's guard depends
+  //              on. ADR-0030 deliberately does not reach into it.
+  'apps/mobile/src/lib/health.ts': ['d', 'start', 'new Date(s.endDate)', 'new Date(end)'],
+  // The widget's FALLBACK comparison for blobs written before `dayEndsMs`
+  // existed (#77 Q4, shipped in `9c6d8efd`). `widgetView` prefers that field,
+  // which the phone computes with the user's boundary; this argument is only
+  // reached for a snapshot that predates it. Neither this file nor
+  // `Glance.swift` re-derives a day.
+  'apps/mobile/src/widgets/render.tsx': ['now'],
   // Analytics buffers flush per CALENDAR day on purpose. This is internal
   // bookkeeping — never shown to a user, never fed to the estimator — and
   // moving it would only change which UTC-ish bucket a batch flushes in.
@@ -159,11 +177,10 @@ if (listOnly) {
   process.exit(0);
 }
 
-// The ratchet. Deliberately NOT zero: what is left is blocked on ADR-0030's Q4
-// and Q5, which are decisions rather than code. It may only ever go DOWN, and
-// the check fails in BOTH directions — so neither a new site nor a finished
-// conversion can pass unnoticed.
-const BASELINE = 10;
+// The ratchet, now at ZERO — ADR-0030 step 3 is complete. It still fails in
+// BOTH directions: a new unexempted site is a latent bug, and there is nothing
+// left to convert, so any drop would mean the check itself broke.
+const BASELINE = 0;
 
 if (total > BASELINE) {
   failed = true;
@@ -182,6 +199,6 @@ if (total > BASELINE) {
 }
 
 if (!failed) {
-  console.log(`✓ day boundary (ADR-0030): localDateKey gone; ${total} call(s) awaiting step 3`);
+  console.log('✓ day boundary (ADR-0030): localDateKey gone; step 3 complete, 0 unexempted call(s)');
 }
 process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Closes #77

The rule is one sentence: **we derive the day only when the source did not.**

That splits "the importers", which looked like one class and are three:

| Site | Decision | Why |
|---|---|---|
| Raw quantity samples — weight, water (iOS + Android) | **Converted** to `dayKeyAt` | A sample carries an instant and no day. The day is ours to choose. |
| OS-bucketed daily totals — steps, active energy | **Keep the calendar date** | The OS made the bucket, at calendar midnight, over a full 00:00–24:00 window. Re-keying its start under a 03:00 boundary would file a whole calendar day's steps as the *previous* user-day. |
| Sleep (iOS + Android) | **Keep the wake-day rule** | A night belongs to the morning you woke — ADR-0033's rule, and what #80's guard depends on. |

The first two live a few lines apart in the same function, which is why "the importers" was never a single answer.

`readSamples` now takes the boundary. `importScalars` already read it once per run for the sleep guard, so this costs no extra profile read.

### The coupling that made this wait

`writeImportedBlocks` matches an imported block's day **against the day of a session the user already logged**. Converting one side only would stop a 00:30 run finding its own session and silently write a duplicate day. Both moved in the same commit, and `health-import-day-boundary.test.ts` asserts they agree under both boundaries **and** that they would disagree if only one had moved.

### Q4 needed no code

`widgets/render.tsx`'s `calendarDateKey` is the **fallback** for snapshots written before `dayEndsMs` existed (shipped in `9c6d8efd`); `widgetView` prefers that field, which the phone computes with the user's boundary. So Q4's answer is "the native surfaces receive the boundary", not "they're pinned to midnight".

### The ratchet is at 0

`BASELINE` 10 → 0. All five survivors are exempted **by argument** with a reason each — a line number goes stale and a whole-file exemption would hide the next call added to that file. It still fails in both directions.

ADR-0030 flips to **ACCEPTED** with Amendment 5 recording both answers, which is #77's definition of done.

**Inert for every existing account**: all are on `MIDNIGHT`, under which `dayKeyAt` *is* the calendar date.

core 1249 · mobile 454 · web 206 · tsc clean · lint at its baseline. JS-only → ships by OTA.