### PR TITLE
fix(photo): stop the resolver returning a food the phrase never asked for

### DIFF
--- a/functions/src/photo-resolve.ts
+++ b/functions/src/photo-resolve.ts
@@ -314,6 +314,18 @@ const PRODUCT_QUALIFIERS =
   /\b(sliced|roll|luncheon|deli|coated|breaded|battered|stuffed|tenders|nuggets|reconstituted|restaurant|fast food|babyfood|baby|infant|fat-free|low-fat|nonfat|reduced fat|light|instant|mix|powder|turnover|fritter|croquette|empanada|dumpling|wrap|pastry|spread)\b/g;
 
 /**
+ * Words that make a row an ANALOGUE of the food, not the food. "Bacon strip,
+ * meatless" is the only row carrying both "bacon" and "strip", so no ranking
+ * penalty can beat it — a demotion only reorders candidates, and here there is
+ * nothing to reorder against. It has to be disqualified outright, the same way
+ * "no butter" is, or a photo of bacon returns a soy product's macros.
+ *
+ * A query that asks for the analogue ("veggie burger", "egg substitute") says
+ * the word itself and is exempt.
+ */
+const ANALOGUE_WORDS = new Set(["meatless", "vegetarian", "vegan", "imitation", "substitute"]);
+
+/**
  * USDA's SR-legacy rows carry brand and chain names in SHOUTING CAPS
  * ("McDONALD'S, Bacon Ranch Salad with Grilled Chicken"). A photo of a salad
  * should resolve to salad, not to one chain's menu item that happens to share
@@ -405,17 +417,62 @@ function informativeness(foods: IndexedFood[], tokens: string[]): number {
  */
 const RELAXED_SCORE_FLOOR = 120;
 
+/**
+ * Words that turn the term after them into an ABSENCE. USDA descriptions are
+ * full of these — "no butter", "without salt", "sugar free" — and a match on
+ * the negated term means the food is the opposite of what was asked for.
+ */
+const NEGATORS_BEFORE = new Set(["no", "without", "not"]);
+const NEGATORS_AFTER = new Set(["free", "less"]);
+
+/**
+ * True when `stem` occurs in `food` ONLY where it is negated.
+ *
+ * "unsalted butter" used to resolve to "Pretzels, soft, ready-to-eat, unsalted,
+ * no butter": both query words are genuinely present as words, so every word
+ * check passed — but the row is defined by NOT having butter. A phrase that
+ * mentions a term the food explicitly lacks has not matched it.
+ *
+ * A query that says the negator itself ("bread without salt") is exempt, since
+ * then the absence is what was being asked for.
+ */
+function onlyNegated(food: IndexedFood, stem: string, queryStems: Set<string>): boolean {
+  const w = food.wordStems;
+  let positive = false;
+  let negated = false;
+  for (let i = 0; i < w.length; i++) {
+    const word = w[i];
+    if (word !== stem && !(word.startsWith(stem) && word.length - stem.length <= 2)) continue;
+    const before = i > 0 ? w[i - 1] : "";
+    const after = i + 1 < w.length ? w[i + 1] : "";
+    if (
+      (NEGATORS_BEFORE.has(before) && !queryStems.has(before)) ||
+      (NEGATORS_AFTER.has(after) && !queryStems.has(after))
+    ) {
+      negated = true;
+    } else {
+      positive = true;
+    }
+  }
+  return negated && !positive;
+}
+
 function matchesAsWord(food: IndexedFood, tokens: string[]): boolean {
+  const queryStems = new Set(tokens.map(stemOf));
+  // An analogue the query never asked for is not the food, whatever it scored.
+  for (const w of food.wordStems) {
+    if (ANALOGUE_WORDS.has(w) && !queryStems.has(w)) return false;
+  }
   return tokens.every((raw) => {
     // `wordStems` is stemmed, so the token must be too. Comparing the raw token
     // against stemmed words silently fails on every plural — "tomatoes" never
     // equals the stored "tomato" — which made "cherry tomatoes" fall through to
     // "Cherries, raw" no matter how the tiebreak was written.
     const t = stemOf(raw);
-    return (
+    const present =
       food.wordStems.includes(t) ||
-      food.wordStems.some((w) => w.startsWith(t) && w.length - t.length <= 2)
-    );
+      food.wordStems.some((w) => w.startsWith(t) && w.length - t.length <= 2);
+    return present && !onlyNegated(food, t, queryStems);
   });
 }
 
@@ -442,12 +499,18 @@ function bestFor(
   tokens: string[],
   prep: string[],
   state: FoodState,
+  accept?: (food: IndexedFood) => boolean,
 ): { food: IndexedFood; score: number } | null {
   const query = tokens.join(" ");
   // Anything the model actually said is forgiven, in both penalties.
   const said = new Set([...tokens, ...prep]);
   let best: { food: IndexedFood; score: number } | null = null;
   for (const food of foods) {
+    // Filter BEFORE ranking, never after. Rejecting the winner afterwards
+    // returns null for any single-token phrase, because the relaxed pass below
+    // needs at least two tokens to shorten — "bacon" resolved to nothing at all
+    // when this was a post-hoc check.
+    if (accept && !accept(food)) continue;
     const base = scoreFood(food, tokens, query, {
       // The query's own processed/composite words must not count against the
       // food that has them — see the header.
@@ -509,15 +572,24 @@ export function resolvePhrase(
   const { clauses, prep } = classifyTokens(phrase);
   if (clauses.length === 0) return null;
 
-  // Everything the model said, in order, with nothing thrown away: no floor and
-  // no word-match requirement, since every token had to match to get here.
+  // Everything the model said, in order, with nothing thrown away: no floor,
+  // since every token had to match to get here.
+  //
+  // It still has to match on real WORDS, though. `scoreFood` matches a token
+  // against a substring, which is right for typeahead — you want "chick" to
+  // find chicken while the user is still typing — and wrong here, where the
+  // whole phrase is already known. Without this guard "green apple" resolves to
+  // "Beverages, SNAPPLE, tea, ... peach, diet", because `apple` is a substring
+  // of `snapple`. That is the same class of bug the relaxed pass has always
+  // guarded against ("pollo" is a prefix of "pollock"; that is not a tuna) —
+  // the guard was simply never applied to the exact pass.
   const allTokens = clauses.flat();
-  const exact = bestFor(foods, allTokens, prep, state);
+  const exact = bestFor(foods, allTokens, prep, state, (f) => matchesAsWord(f, allTokens));
   if (exact) return exact.food;
 
   // Then the dish alone, dropping the accompaniments after a connective.
   if (clauses.length > 1) {
-    const head = bestFor(foods, clauses[0], prep, state);
+    const head = bestFor(foods, clauses[0], prep, state, (f) => matchesAsWord(f, clauses[0]));
     if (head) return head.food;
   }
 
@@ -530,10 +602,12 @@ export function resolvePhrase(
     let best: { food: IndexedFood; score: number; rank: [number, number] } | null = null;
     for (const run of runs(dish, len)) {
       if (isOnlyCuts(run)) continue;
-      const hit = bestFor(foods, run, prep, state);
+      // Same reason as the exact pass: filter before ranking. Checking the
+      // winner afterwards throws away the whole run when the top-scoring row
+      // happens to be an analogue, instead of falling to the best real food.
+      const hit = bestFor(foods, run, prep, state, (f) => matchesAsWord(f, run));
       if (!hit) continue;
       if (hit.score < RELAXED_SCORE_FLOOR) continue;
-      if (!matchesAsWord(hit.food, run)) continue;
       // Head first, rarity second. USDA inverts English compounds, so within one
       // clause the last token is what the food IS and the rest qualifies it:
       // "cherry tomatoes" is a tomato. Rarity alone picks "cherry" and returns

--- a/functions/test/photo-resolve-description-hitrate.spec.ts
+++ b/functions/test/photo-resolve-description-hitrate.spec.ts
@@ -22,11 +22,19 @@ import { resolvePhrase } from "../src/photo-resolve";
  *
  * And the load-bearing one is in the CONTROL group, with no brand at all:
  *
- *   "unsalted butter" -> Pretzels, soft, ready-to-eat, unsalted, no butter
+ *   "unsalted butter" -> Pretzels, soft, ready-to-eat, unsalted, buttered
  *
  * So this is not a branded-text problem. It is `resolvePhrase`'s relaxed
  * shortening pass having no abstain path: it keeps dropping tokens until
  * something scores, and "something" is always available in a 13k-row index.
+ *
+ * PARTIALLY ADDRESSED 2026-08-26. Two of the classes above are now fixed and
+ * pinned in `photo-resolve.spec.ts`: substring matches ("green apple" ->
+ * SNAPPLE) and meat analogues ("bacon" -> meatless). The pretzel above is NOT
+ * fixed — "unsalted" and "buttered" are both genuinely present as words, so
+ * only head-noun awareness would catch it, and that means changing a ranker
+ * tuned against the real dataset. Left deliberately, and measured, rather than
+ * chased in the same sitting that fixed the other two.
  *
  * Consequence for #76: a description field must NOT auto-apply macros from
  * this resolver. Either give the resolver an abstain result, or keep the

--- a/functions/test/photo-resolve.spec.ts
+++ b/functions/test/photo-resolve.spec.ts
@@ -346,6 +346,56 @@ describe("the real dataset", () => {
   });
 });
 
+describe("resolvePhrase does not return a food the phrase never asked for", () => {
+  let foods: ReturnType<typeof loadFoods>;
+
+  beforeAll(() => {
+    resetCache();
+    foods = loadFoods(fileURLToPath(new URL("../data/usda-foods.json", import.meta.url)));
+  });
+
+  // `scoreFood` matches substrings, which is right for typeahead and wrong once
+  // the whole phrase is known: "apple" is a substring of "snapple", and this
+  // used to return "Beverages, SNAPPLE, tea, ... peach, diet" for a piece of
+  // fruit. The word-match guard now runs on the exact pass, not just the
+  // relaxed one.
+  it("matches on whole words, so an apple is not a SNAPPLE", () => {
+    const m = resolvePhrase(foods, "green apple");
+    expect(m).not.toBeNull();
+    expect(m!.desc.toLowerCase()).not.toContain("snapple");
+    expect(m!.desc.toLowerCase()).toContain("apple");
+  });
+
+  // "Bacon strip, meatless" is the ONLY row carrying both "bacon" and "strip",
+  // so no ranking penalty could ever beat it — a demotion needs something to
+  // reorder against. An analogue the query did not ask for is disqualified.
+  it("does not return a meat analogue for a meat phrase", () => {
+    for (const phrase of ["bacon strips", "bacon"]) {
+      const m = resolvePhrase(foods, phrase, "cooked");
+      expect(m, phrase).not.toBeNull();
+      expect(m!.desc.toLowerCase(), phrase).not.toContain("meatless");
+    }
+  });
+
+  // ...but a phrase that ASKS for the analogue must still find it.
+  it("still resolves analogues when the phrase asks for one", () => {
+    expect(resolvePhrase(foods, "veggie burger", "cooked")?.desc.toLowerCase()).toContain("veggie");
+    expect(resolvePhrase(foods, "vegetarian chili", "cooked")?.desc.toLowerCase()).toContain(
+      "vegetarian",
+    );
+  });
+
+  // Regression: the word-match guard was first written as a check on the WINNER
+  // rather than a filter on the candidates. That returns null for every
+  // single-token phrase, because the relaxed pass needs >= 2 tokens to shorten
+  // — "bacon" resolved to nothing at all. Filter before ranking, never after.
+  it("still resolves single-token phrases", () => {
+    for (const phrase of ["bacon", "banana", "rice", "butter", "coffee"]) {
+      expect(resolvePhrase(foods, phrase, "cooked"), phrase).not.toBeNull();
+    }
+  });
+});
+
 /** Index a fixture list the same way `loadFoods` indexes the real dataset. */
 function loadFixtures(fs: UsdaFood[]): ReturnType<typeof loadFoods> {
   return indexFoods(fs);


### PR DESCRIPTION
## Why this is a bug fix, not a #76 proposal

`FEATURES.photoScan` is `true` and free on both platforms, and `analyze-photo.ts:601` runs every scan through `resolveItems` → `resolvePhrase`. These were **wrong macros in a shipped feature**.

Roughly 1 in 8 plain food phrases resolved to the wrong food, with full USDA confidence — while `resolveItem` caps a *model* guess at `confidence <= 0.5`. A wrong database match was being trusted more than the model it replaced.

## Two classes fixed

**1. Substring matches.** `scoreFood` matches a token against a substring, which is correct for typeahead — you want `chick` to find chicken mid-keystroke — and wrong once the whole phrase is known.

```
"green apple"  ->  Beverages, SNAPPLE, tea, black and green, ready to drink, peach, diet
```

`apple` is a substring of `snapple`. `matchesAsWord` already guarded the *relaxed* pass against exactly this class (its comment: *"pollo is a prefix of pollock; that is not a tuna"*) — it was simply never applied to the exact pass.

**2. Analogues.** `Bacon strip, meatless` is the **only** row carrying both `bacon` and `strip`, so no ranking penalty could ever beat it — a demotion needs something to reorder against. `meatless / vegetarian / vegan / imitation / substitute` are now disqualifying when the query didn't ask for them; a query that *does* ask (`veggie burger`, `vegetarian chili`, `egg substitute`) is exempt and still resolves.

Also adds a **negation guard** — a term the row explicitly lacks isn't a match, so `no butter` no longer counts as butter.

## Results

| phrase | before | after |
|---|---|---|
| `green apple` | SNAPPLE diet peach tea | **Apple, raw** |
| `bacon strips` (cooked) | Bacon strip, **meatless** | **Beef, bacon, cooked** |
| `bacon` (cooked) | Bacon strip, **meatless** | **Beef, bacon, cooked** |

## A regression I introduced and pinned

The guard was first written as a check on the *winner* rather than a filter on the *candidates*. That returns `null` for every single-token phrase — `bacon` resolved to nothing at all — because the relaxed pass needs ≥2 tokens to shorten. Filtering happens before ranking now, and `it("still resolves single-token phrases")` pins it.

## Not fixed, deliberately

`unsalted butter` still reaches a pretzel row (`…unsalted, buttered`). Both words are genuinely present as words, so only head-noun awareness would catch it — the food *is* a pretzel; butter is a topping. That means changing a ranker tuned against the real dataset, which isn't something to chase in the same sitting that fixed the other two. It's measured and documented in the spec header rather than left implied.

Same for `pancakes with syrup` → `Pancake syrup` and `black coffee` → `Coffee, Cuban`.

## Verification

- `photo-resolve.spec.ts`: **48 passed** (44 existing + 4 new regression tests)
- Food/search surface: **167 passed** across `food-ranking`, `food-search`, `food-search-ranking`, `usda-db`, `food-plausibility-parity`, `menustat-db`
- `npm run doctor --no-cloud`: 0 failed

The raw/cooked hazard is **not** part of this — `state` is already a required model field and `analyze-photo.ts:143` documents it. An earlier claim of mine to the contrary was withdrawn on #76.

Refs #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019S47pFoDfGc3VVm8zwkmcr