### PR TITLE
fix(push): the hourly tasks are WEB-ONLY, and now say so in code (#113)

### DIFF
--- a/functions/src/push-reminders.ts
+++ b/functions/src/push-reminders.ts
@@ -7,6 +7,114 @@ import { db } from "./init";
 // Plain async task run by the hourly dispatcher (`hourly-tasks.ts`) —
 // no longer its own scheduled function. Consolidating the hourly jobs
 // keeps us within Cloud Scheduler's 3-job free tier.
+//
+// ─── `fcmToken` IS A WEB PUSH REGISTRATION. READ THIS BEFORE WIRING MOBILE ───
+//
+// Both tasks below select users by `fcmToken != null` and by nothing else, and
+// that is safe ONLY because the field is written by exactly one client: the
+// Angular PWA (`FirebaseService.saveFcmToken`, a VAPID web-push registration).
+//
+// **The trap is that the obvious mobile implementation would silently enrol
+// every app user in a daily push they never asked for.** `expo-notifications`'
+// `getDevicePushTokenAsync()` returns, on Android, a genuine FCM registration
+// token — exactly what `messaging.send({ token })` accepts. So storing it in
+// `fcmToken` LOOKS like it just works, and the sender below would immediately
+// start pushing to it. Two things then go wrong at once:
+//
+//  1. **A 20:00 reminder nobody set.** `reminderHour ?? 20` is the intended web
+//     default (on web, granting push permission IS the opt-in, and
+//     `saveFcmToken` deliberately writes no hour). Mobile's reminder model is a
+//     different shape entirely — a PER-MEAL schedule in AsyncStorage, planned by
+//     `planReminders` in packages/core — so an app user would get a fourth,
+//     unrequested nudge on top of the three they configured, from a schedule
+//     that is invisible in the app and unchangeable from it.
+//  2. **A push that leaves the app.** `runDayThreeCoachPush` sends a `webpush`
+//     block linking to `https://ignia.fit/`. Correct for a browser; wrong for a
+//     native client, which wants the `ignia://` scheme. And it is latched
+//     one-shot per user, so a mobile user who receives it and taps into nothing
+//     has burned their only chance at it.
+//
+// **So mobile push MUST use its own field** (`expoPushToken`, per the transport
+// chosen in #112) and its own sender. `webPushRecipient` below encodes that
+// rule rather than leaving it to a comment, and `push-reminders.spec.ts` fails
+// the build if either task starts selecting a mobile registration.
+//
+// This is a NO-OP today — nothing writes `expoPushToken` yet — and becomes
+// protective the moment #112 ships. That ordering is the point (#113).
+
+/** How the daily reminder falls back when the user never picked an hour. On
+ *  web, granting permission is the opt-in and this is the intended default. */
+export const DEFAULT_REMINDER_HOUR = 20;
+
+/**
+ * Expo's own push tokens are opaque strings of this shape. FCM registration
+ * tokens never look like this, so a value matching it in `fcmToken` means a
+ * mobile client wrote to the wrong field — belt-and-braces beside the
+ * `expoPushToken` check, which is the real guard.
+ */
+export function looksLikeExpoPushToken(token: string): boolean {
+  return /^Expo(nent)?PushToken\[/.test(token);
+}
+
+/** The fields these tasks read off a user document. */
+export interface PushProfile {
+  fcmToken?: unknown;
+  /** Present ⇒ this account has a MOBILE push registration (#112). */
+  expoPushToken?: unknown;
+  reminderHour?: unknown;
+  timezoneOffsetMin?: unknown;
+}
+
+export interface WebPushRecipient {
+  token: string;
+  reminderHour: number;
+  tzOffsetMin: number;
+}
+
+/**
+ * The web-push registration for this user, or `null` if there is not one.
+ *
+ * Returns null when the account holds a MOBILE registration, even if it also
+ * holds an `fcmToken`. That direction is deliberate: a user with the app has
+ * local per-meal reminders already, and a second server-sent nudge they never
+ * configured is the failure this function exists to prevent. Withholding a push
+ * is recoverable; sending an unrequested one at 20:00 is what makes people
+ * disable notifications for good.
+ */
+export function webPushRecipient(data: PushProfile): WebPushRecipient | null {
+  if (data.expoPushToken != null && data.expoPushToken !== '') return null;
+
+  const token = data.fcmToken;
+  if (typeof token !== 'string' || token === '') return null;
+  if (looksLikeExpoPushToken(token)) return null;
+
+  const hour = typeof data.reminderHour === 'number' ? data.reminderHour : DEFAULT_REMINDER_HOUR;
+  if (!Number.isInteger(hour) || hour < 0 || hour > 23) return null;
+
+  const tz = typeof data.timezoneOffsetMin === 'number' ? data.timezoneOffsetMin : 0;
+  return { token, reminderHour: hour, tzOffsetMin: tz };
+}
+
+/**
+ * The user's local hour right now.
+ *
+ * `getTimezoneOffset()` is positive west of UTC (+300 for UTC-5), i.e.
+ * UTC = local + offset, so local = UTC - offset.
+ */
+export function localHour(nowUtc: Date, tzOffsetMin: number): number {
+  return (nowUtc.getUTCHours() - Math.round(tzOffsetMin / 60) + 24) % 24;
+}
+
+/**
+ * Is this the one hour of the user's day the reminder may fire?
+ *
+ * A SINGLE hour, not a window: the dispatcher runs hourly, and an earlier
+ * two-hour window (`reminderHour..reminderHour+1`) sent everybody two pushes a
+ * day. Do not widen it.
+ */
+export function isReminderHour(recipient: WebPushRecipient, nowUtc: Date): boolean {
+  return localHour(nowUtc, recipient.tzOffsetMin) === recipient.reminderHour;
+}
 
 export async function runDailyReminders(): Promise<void> {
     const messaging = getMessaging();
@@ -26,19 +134,14 @@ export async function runDailyReminders(): Promise<void> {
     await Promise.allSettled(
       usersSnap.docs.map(async (userDoc) => {
         const data = userDoc.data();
-        const token = data.fcmToken as string;
-        const reminderHour = (data.reminderHour as number) ?? 20;
-        const tzOffsetMin = (data.timezoneOffsetMin as number) ?? 0;
 
-        // Compute the user's local hour.
-        // getTimezoneOffset() returns positive for west of UTC (e.g., +300 for UTC-5,
-        // meaning UTC = local + offset). So local = UTC - offset.
-        const userLocalHour = (nowUtc.getUTCHours() - Math.round(tzOffsetMin / 60) + 24) % 24;
+        // Web registrations only — see the header. A mobile account is skipped
+        // here even when it carries an `fcmToken`.
+        const recipient = webPushRecipient(data);
+        if (!recipient) return;
+        if (!isReminderHour(recipient, nowUtc)) return;
 
-        // Single-hour window — schedule fires hourly, so allowing >1 hour
-        // would double-fire the push. Earlier code used a 2-hour window
-        // (reminderHour..reminderHour+1) and users got two pings per day.
-        if (userLocalHour !== reminderHour) return;
+        const { token, tzOffsetMin } = recipient;
 
         // Check if they logged today (in their local timezone).
         const userNow = new Date(nowUtc.getTime() - tzOffsetMin * 60 * 1000);
@@ -115,11 +218,15 @@ export async function runDayThreeCoachPush(): Promise<void> {
         const data = userDoc.data();
         if (data.dayThreeCoachPushSent) return; // already nudged.
 
-        const token = data.fcmToken as string;
-        const reminderHour = (data.reminderHour as number) ?? 20;
-        const tzOffsetMin = (data.timezoneOffsetMin as number) ?? 0;
-        const userLocalHour = (nowUtc.getUTCHours() - Math.round(tzOffsetMin / 60) + 24) % 24;
-        if (userLocalHour !== reminderHour) return;
+        // Web registrations only — see the header. This one matters more than
+        // the daily reminder: it is latched one-shot per user, so firing it at
+        // a mobile client would spend the single chance on a `webpush` payload
+        // linking to a web page the app cannot open.
+        const recipient = webPushRecipient(data);
+        if (!recipient) return;
+        if (!isReminderHour(recipient, nowUtc)) return;
+
+        const { token } = recipient;
 
         // Oldest log — single read, no aggregate needed. If the oldest
         // log is ≥3 days old the user has been around long enough for

--- a/functions/test/push-reminders.spec.ts
+++ b/functions/test/push-reminders.spec.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_REMINDER_HOUR,
+  isReminderHour,
+  localHour,
+  looksLikeExpoPushToken,
+  webPushRecipient,
+} from "../src/push-reminders";
+
+/**
+ * #113 — the hourly push tasks must never fire at a mobile client.
+ *
+ * These two tasks have run hourly in production for months and were safe only
+ * because exactly one client writes `fcmToken`: the Angular PWA. Nothing in the
+ * code said so, and the obvious mobile implementation would have broken it
+ * silently — `getDevicePushTokenAsync()` returns a real FCM registration token
+ * on Android, so storing it in `fcmToken` looks like it just works and the
+ * existing sender would immediately start pushing to it.
+ *
+ * The user-visible result would be a 20:00 reminder nobody set, on top of the
+ * per-meal reminders the app already schedules locally, from a schedule that is
+ * invisible in the app and unchangeable from it.
+ *
+ * So the rule is enforced here rather than described in a comment.
+ */
+
+const webProfile = () => ({ fcmToken: "fcm-abc", timezoneOffsetMin: 300 });
+
+describe("webPushRecipient", () => {
+  it("accepts a plain web registration", () => {
+    expect(webPushRecipient(webProfile())).toEqual({
+      token: "fcm-abc",
+      reminderHour: DEFAULT_REMINDER_HOUR,
+      tzOffsetMin: 300,
+    });
+  });
+
+  it("defaults the hour, because on web the permission grant IS the opt-in", () => {
+    // `FirebaseService.saveFcmToken` deliberately writes no `reminderHour`.
+    expect(webPushRecipient(webProfile())?.reminderHour).toBe(20);
+  });
+
+  it("honours an hour the user chose", () => {
+    expect(webPushRecipient({ ...webProfile(), reminderHour: 7 })?.reminderHour).toBe(7);
+  });
+
+  it("declines a profile with no token", () => {
+    expect(webPushRecipient({})).toBeNull();
+    expect(webPushRecipient({ fcmToken: "" })).toBeNull();
+    expect(webPushRecipient({ fcmToken: null })).toBeNull();
+  });
+
+  it("declines a non-string token rather than sending to it", () => {
+    expect(webPushRecipient({ fcmToken: 42 })).toBeNull();
+  });
+
+  it("declines an out-of-range hour instead of pushing at a wrong one", () => {
+    expect(webPushRecipient({ ...webProfile(), reminderHour: 24 })).toBeNull();
+    expect(webPushRecipient({ ...webProfile(), reminderHour: -1 })).toBeNull();
+    expect(webPushRecipient({ ...webProfile(), reminderHour: 7.5 })).toBeNull();
+  });
+
+  it("assumes UTC when no timezone was ever written", () => {
+    expect(webPushRecipient({ fcmToken: "t" })?.tzOffsetMin).toBe(0);
+  });
+
+  // ── The regression this file exists for ──────────────────────────────
+
+  it("DECLINES an account holding a mobile registration", () => {
+    expect(webPushRecipient({ expoPushToken: "ExponentPushToken[xyz]" })).toBeNull();
+  });
+
+  it("DECLINES a mobile account even when it also carries an fcmToken", () => {
+    // This is the shape that would exist if a user has both the PWA and the
+    // app. They already get local per-meal reminders; a second server-sent
+    // nudge they never configured is what this prevents. Withholding a push is
+    // recoverable — an unrequested 20:00 one is how people turn notifications
+    // off for good.
+    expect(
+      webPushRecipient({ ...webProfile(), expoPushToken: "ExponentPushToken[xyz]" }),
+    ).toBeNull();
+  });
+
+  it("DECLINES an Expo token misfiled into fcmToken", () => {
+    // Belt and braces. A native Android FCM token written to `fcmToken` is
+    // genuinely indistinguishable from a web one, which is exactly why the
+    // `expoPushToken` field above is the real guard and this is only the
+    // second line of defence.
+    expect(webPushRecipient({ fcmToken: "ExponentPushToken[xyz]" })).toBeNull();
+  });
+});
+
+describe("looksLikeExpoPushToken", () => {
+  it.each(["ExponentPushToken[abc]", "ExpoPushToken[abc]"])("matches %s", (t) => {
+    expect(looksLikeExpoPushToken(t)).toBe(true);
+  });
+
+  it("does not match an FCM registration token", () => {
+    expect(looksLikeExpoPushToken("fPz1k:APA91bH-Xyz_123")).toBe(false);
+  });
+});
+
+describe("localHour", () => {
+  it("converts west of UTC", () => {
+    // Puerto Rico is UTC-4 ⇒ getTimezoneOffset() === 240.
+    expect(localHour(new Date("2026-08-29T00:00:00Z"), 240)).toBe(20);
+  });
+
+  it("converts east of UTC", () => {
+    // Berlin in summer is UTC+2 ⇒ getTimezoneOffset() === -120.
+    expect(localHour(new Date("2026-08-29T00:00:00Z"), -120)).toBe(2);
+  });
+
+  it("wraps rather than going negative", () => {
+    expect(localHour(new Date("2026-08-29T02:00:00Z"), 300)).toBe(21);
+  });
+});
+
+describe("isReminderHour", () => {
+  const at = (hour: number) => ({ token: "t", reminderHour: hour, tzOffsetMin: 240 });
+
+  it("fires on the user's chosen local hour", () => {
+    expect(isReminderHour(at(20), new Date("2026-08-29T00:00:00Z"))).toBe(true);
+  });
+
+  it("is a SINGLE hour, not a window", () => {
+    // An earlier two-hour window sent everyone two pushes a day. The dispatcher
+    // runs hourly, so widening this re-creates that bug.
+    expect(isReminderHour(at(20), new Date("2026-08-29T01:00:00Z"))).toBe(false);
+    expect(isReminderHour(at(20), new Date("2026-08-28T23:00:00Z"))).toBe(false);
+  });
+});


### PR DESCRIPTION
**Fixed and deployed** — `hourlytasks-00025-qow`, verified with a forced Cloud Scheduler run (executes clean, no `failed:` lines from the dispatcher).

## What shipped

`webPushRecipient()` now encodes the web-only rule instead of a comment carrying it:

- declines any account holding an **`expoPushToken`** — even when it *also* has an `fcmToken`;
- declines an **Expo-shaped token misfiled into `fcmToken`** (belt and braces — a native Android FCM token is genuinely indistinguishable from a web one, which is exactly why the field separation is the real guard);
- validates the hour and the token type instead of coercing them.

The timezone and single-hour logic came out as `localHour` / `isReminderHour`, tested — following the `weekly-digest-window` precedent, since that task already had the same arithmetic extracted. The single-hour rule is now pinned: an earlier two-hour window sent everybody two pushes a day, and widening it re-creates that.

**A mobile account is skipped even when it carries an `fcmToken`.** That direction is deliberate: the user already has local per-meal reminders, and withholding a push is recoverable where an unrequested 20:00 one is how people turn notifications off for good.

Suite 571 → 589.

## The measurement, which reframes #112

Audited against production: **0 of 43 accounts hold an `fcmToken`.**

So both tasks have been iterating an empty result set every hour, and **the web push path has never delivered anything to anyone.** The sender exists and executes — that part of my #112 write-up stands — but it has never been exercised end to end against a real token. #112 must not treat the send path as proven; it is untested code that happens to run.

It also means this change is a **no-op today** (0 accounts hold either token) and becomes protective the moment #112 ships. That ordering was the whole point of this ticket.

## One thing deliberately NOT done

The `?? 20` default is left alone. It is correct for web: `FirebaseService.saveFcmToken` writes no `reminderHour`, so granting permission *is* the opt-in there and 20:00 is the intended fallback. My first read of this ticket assumed that default was itself the bug; reading the web client showed it is the design. The bug was only ever that mobile would inherit it.
