### PR TITLE
feat(milestones): goal-reached, behind the human the schema cannot supply (#110)

### DIFF
--- a/apps/mobile/src/__tests__/body-chart-caption.test.tsx
+++ b/apps/mobile/src/__tests__/body-chart-caption.test.tsx
@@ -1,3 +1,10 @@
+// ody.tsx now reaches milestones, which import @/lib/ledger -> firebase's
+// untranspiled ESM. Mocked for the same reason @/lib/auth already is here.
+jest.mock('@/lib/ledger', () => ({
+  recordMilestone: jest.fn(),
+  subscribeMilestones: () => () => {},
+}));
+
 import { renderWithProviders as render } from '@/test-utils';
 import React from 'react';
 

--- a/apps/mobile/src/__tests__/body.test.tsx
+++ b/apps/mobile/src/__tests__/body.test.tsx
@@ -1,3 +1,10 @@
+// ody.tsx now reaches milestones, which import @/lib/ledger -> firebase's
+// untranspiled ESM. Mocked for the same reason @/lib/auth already is here.
+jest.mock('@/lib/ledger', () => ({
+  recordMilestone: jest.fn(),
+  subscribeMilestones: () => () => {},
+}));
+
 import { fireEvent, renderWithProviders as render, waitFor } from '@/test-utils';
 import React from 'react';
 import type { Measurement } from '@macrolog/core';

--- a/apps/mobile/src/__tests__/milestone-note.test.tsx
+++ b/apps/mobile/src/__tests__/milestone-note.test.tsx
@@ -1,0 +1,101 @@
+jest.mock('@/lib/auth', () => ({
+  useAuth: () => ({ user: { uid: 'u1' }, profile: null }),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { waitFor } from '@testing-library/react-native';
+import { fireEvent, renderWithProviders as render } from '@/test-utils';
+import { MilestoneNote } from '@/components/MilestoneNote';
+import type { MilestoneKey } from '@macrolog/core';
+
+/**
+ * The first run BACKFILLS, and that is what this covers.
+ *
+ * Every milestone an account has ever earned is recorded the day the feature
+ * arrives, so an existing user's first note is not one line. The owner's own
+ * screenshot showed four stacked above the fold on Today with no way to clear
+ * them; a hundred-day streak would show eight. Both fixes — the cap and the
+ * dismiss — came from that screenshot rather than from any test, so they get
+ * one here.
+ */
+
+const FIVE: MilestoneKey[] = [
+  'first-weigh-in',
+  'first-workout',
+  'streak-7',
+  'streak-14',
+  'streak-30',
+];
+
+const noop = () => {};
+
+describe('MilestoneNote', () => {
+  // The dismissal is a real AsyncStorage write and the mock persists across
+  // tests in a file — without this, one test's dismiss silently hides the row
+  // in the next and the failure looks like a broken component.
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('renders nothing when nothing was recorded today', async () => {
+    const { queryByTestId } = await render(
+      <MilestoneNote keys={[]} dayKey="2026-08-30" onOpen={noop} />,
+    );
+    // Not an empty shell — a permanent fixture announcing that nothing
+    // happened is worse than no row.
+    expect(queryByTestId('milestone-note')).toBeNull();
+  });
+
+  it('caps the visible titles and counts the rest', async () => {
+    const { getByTestId, queryByText } = await render(
+      <MilestoneNote keys={FIVE} dayKey="2026-08-30" onOpen={noop} />,
+    );
+    expect(getByTestId('milestone-note')).toBeTruthy();
+    // Three shown, two counted.
+    expect(queryByText('First weigh-in')).toBeTruthy();
+    expect(queryByText('A week of logging')).toBeTruthy();
+    expect(queryByText('Two weeks of logging')).toBeNull();
+    expect(queryByText('+2 more')).toBeTruthy();
+  });
+
+  it('shows no counter when everything fits', async () => {
+    const { queryByText } = await render(
+      <MilestoneNote keys={FIVE.slice(0, 2)} dayKey="2026-08-30" onOpen={noop} />,
+    );
+    expect(queryByText(/more$/)).toBeNull();
+  });
+
+  it('opens the archive when the label is pressed', async () => {
+    const onOpen = jest.fn();
+    const { getByTestId } = await render(
+      <MilestoneNote keys={FIVE} dayKey="2026-08-30" onOpen={onOpen} />,
+    );
+    fireEvent.press(getByTestId('milestone-note-open'));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses without asking the caller for anything', async () => {
+    // The dismiss is entirely local: no callback, no write to Firestore, and
+    // it must not require the parent to re-render for the row to go.
+    const { getByTestId, queryByTestId } = await render(
+      <MilestoneNote keys={FIVE} dayKey="2026-08-30" onOpen={noop} />,
+    );
+    fireEvent.press(getByTestId('milestone-note-dismiss'));
+    // `waitFor`, not a synchronous assertion: under React 19 the state update a
+    // press schedules is not committed when `fireEvent.press` returns, so a
+    // direct read here sees the PREVIOUS render (AGENTS.md, from the FastSheet
+    // work).
+    await waitFor(() => expect(queryByTestId('milestone-note')).toBeNull());
+  });
+
+  it('the dismiss and the open are separate targets', async () => {
+    // Nesting one touchable inside another makes which one fired depend on a
+    // few pixels, and these two actions are opposites.
+    const onOpen = jest.fn();
+    const { getByTestId } = await render(
+      <MilestoneNote keys={FIVE} dayKey="2026-08-30" onOpen={onOpen} />,
+    );
+    fireEvent.press(getByTestId('milestone-note-dismiss'));
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/__tests__/milestones-copy.test.ts
+++ b/apps/mobile/src/__tests__/milestones-copy.test.ts
@@ -71,6 +71,39 @@ describe('milestone copy is retrospective in every locale', () => {
     }
   });
 
+  // ── The #110 guardrail, as a test ────────────────────────────────────
+  //
+  // `goal-reached` is the one milestone about an outcome rather than a
+  // behaviour, in a calorie tracker, on a weight number. #110 dropped
+  // `first-5-lb` and `four-weeks-on-target` precisely to avoid weight-magnitude
+  // praise; the prompt is where it would creep back in, one well-meaning copy
+  // edit at a time.
+  describe('the goal prompt asks, and does not congratulate', () => {
+    const GOAL_KEYS = ['milestones.goalAsk', 'milestones.goalAdd', 'milestones.goalDecline'];
+
+    it.each(LOCALES)('%s names no weight and no magnitude', (locale) => {
+      const dict = LOCALE_DEFS[locale as keyof typeof LOCALE_DEFS].dict;
+      for (const key of GOAL_KEYS) {
+        const v = dict[key as keyof typeof dict];
+        // No digits at all: a number here would be a weight, and the whole
+        // point is that this surface never quotes one.
+        expect(v).not.toMatch(/\d/);
+        expect(v).not.toMatch(/\b(lb|lbs|kg|kilo|libra)\b/i);
+      }
+    });
+
+    it.each(LOCALES)('%s congratulates nobody before they answer', (locale) => {
+      const dict = LOCALE_DEFS[locale as keyof typeof LOCALE_DEFS].dict;
+      const ask = dict['milestones.goalAsk' as keyof typeof dict];
+      expect(ask).not.toMatch(
+        /congrat|well done|amazing|proud|felicidades|enhorabuena|parabéns|incrível|orgulh/i,
+      );
+      // It is a question. If it stops ending in one, it has become a statement
+      // about the user's body rather than a request to record a fact.
+      expect(ask.trim().endsWith('?')).toBe(true);
+    });
+  });
+
   it('says "recorded", not "achieved" — the date is when Ignia noticed', () => {
     // For a derived milestone (a streak length is not an event) `earnedAt` is
     // when the app evaluated, not when the act happened. The copy must not

--- a/apps/mobile/src/__tests__/weigh-in-sheet.test.tsx
+++ b/apps/mobile/src/__tests__/weigh-in-sheet.test.tsx
@@ -1,3 +1,10 @@
+// ody.tsx now reaches milestones, which import @/lib/ledger -> firebase's
+// untranspiled ESM. Mocked for the same reason @/lib/auth already is here.
+jest.mock('@/lib/ledger', () => ({
+  recordMilestone: jest.fn(),
+  subscribeMilestones: () => () => {},
+}));
+
 import { fireEvent, renderWithProviders as render } from '@/test-utils';
 
 /**

--- a/apps/mobile/src/app/(app)/body.tsx
+++ b/apps/mobile/src/app/(app)/body.tsx
@@ -26,9 +26,13 @@ import {
   weightBoundsFor,
 } from '@macrolog/core';
 import { BottomSheet } from '@/components/BottomSheet';
+import { GoalMilestonePrompt } from '@/components/GoalMilestonePrompt';
 import { HeaderAvatar } from '@/components/HeaderAvatar';
 import { Sparkline } from '@/components/Sparkline';
 import { useBody } from '@/hooks/useBody';
+import { useMilestoneRecord } from '@/hooks/useMilestones';
+import { useAuth } from '@/lib/auth';
+import { recordMilestone } from '@/lib/ledger';
 import { type I18nKey, type Locale, type TFn, useLocale, useT } from '@/i18n';
 import type { BodyFatInput } from '@macrolog/core';
 import * as haptics from '@/lib/haptics';
@@ -92,7 +96,10 @@ export default function Body() {
     weightSeries,
     projectedSeries,
     goalProgress,
+    goalCrossed,
   } = useBody();
+  const { user } = useAuth();
+  const milestones = useMilestoneRecord(user?.uid);
   const t = useT();
   const locale = useLocale();
   const styles = useThemedStyles(createStyles);
@@ -230,6 +237,18 @@ export default function Body() {
             ) : null}
           </Animated.View>
           </Animated.View>
+
+          {/* The `goal-reached` milestone needs a human, because the schema
+              cannot supply one: `dailyWeights` carries no `source`, so a typed
+              weigh-in and an auto-import are the same document (#110). It sits
+              here rather than on Today because this is where the goal and the
+              trend it is measured against already live. */}
+          <GoalMilestonePrompt
+            visible={goalCrossed && !milestones.earned['goal-reached']}
+            onConfirm={() => {
+              if (user?.uid) void recordMilestone(user.uid, 'goal-reached');
+            }}
+          />
 
           <Animated.View entering={enterUp(1)}>
             <TouchableOpacity style={styles.logBtn} onPress={() => setOpen(true)} testID="log-weight">

--- a/apps/mobile/src/app/(app)/index.tsx
+++ b/apps/mobile/src/app/(app)/index.tsx
@@ -1,5 +1,5 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
-import { router, useLocalSearchParams } from 'expo-router';
+import { type Href, router, useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Alert, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import Animated from 'react-native-reanimated';
@@ -420,7 +420,11 @@ export default function Today() {
               banner without ever having been ranked against one — the exact
               outcome `useTodayNudge`'s ordering exists to prevent. Here it
               reads as what it is: your numbers, then what they added up to. */}
-          <MilestoneNote keys={todaysMilestones} />
+          <MilestoneNote
+            keys={todaysMilestones}
+            dayKey={todayKey}
+            onOpen={() => router.push('/milestones' as Href)}
+          />
 
           <RecalibrationCard suppressed={nudge !== 'recalibration'} />
 

--- a/apps/mobile/src/components/GoalMilestonePrompt.tsx
+++ b/apps/mobile/src/components/GoalMilestonePrompt.tsx
@@ -1,0 +1,115 @@
+import { StyleSheet, Text, View } from 'react-native';
+import Animated from 'react-native-reanimated';
+import { useT } from '@/i18n';
+import { useDismissedStub } from '@/hooks/useDismissedStub';
+import * as haptics from '@/lib/haptics';
+import { enterUp, PressScale } from '@/lib/motion';
+import { useThemedStyles, type Theme } from '@/lib/theme-context';
+import { font, radius, space, type } from '@/theme';
+
+/**
+ * "Add reaching your goal weight to your milestones?" — the human in the loop
+ * that `goal-reached` needs (#110).
+ *
+ * ## Why a question exists at all
+ *
+ * `users/{uid}/dailyWeights/{dateKey}` is `{ weight }` with **no `source`**, so
+ * a hand-typed weigh-in and one auto-imported from Apple Health or Health
+ * Connect are byte-identical. `goalReached()` in core demands manual
+ * provenance, which today's schema simply cannot show — and the guard is not
+ * negotiable, because `useHealthAutoImport` re-imports on every foreground and
+ * one stray 158 lb reading has already moved this project's measured
+ * maintenance from 2,741 to 1,619 kcal.
+ *
+ * The alternative was adding `source` to `dailyWeights`. That is a
+ * `firestore.rules` change on a collection the FROZEN web app also writes, and
+ * `hasOnly` validates the merged document — so getting it wrong starts
+ * rejecting the web's weigh-ins. A cross-frontend rules deploy under a freeze,
+ * for one milestone. **The person answering is cheaper and more honest.**
+ *
+ * ## What this must not become
+ *
+ * It is a **question**, never a celebration. Nothing here congratulates before
+ * the user answers, and nothing names a number — no "you lost 14 lb", no
+ * "goal weight reached!". Weight-magnitude praise is the eating-disorder-
+ * adjacent half that #110 dropped `first-5-lb` and `four-weeks-on-target` to
+ * avoid; re-introducing it in the copy would undo that decision quietly.
+ *
+ * ## Asking twice is worse than never asking
+ *
+ * Declining is remembered per device (AsyncStorage, via the same
+ * `useDismissedStub` the Trends stubs use) — no profile field, no rules change.
+ * Accepting writes the milestone, and `newlyEarned` then filters it on every
+ * device forever, so a "yes" syncs and a "no" does not. That asymmetry is
+ * deliberate and it is the right way round: the cost of a declined prompt
+ * reappearing once on a second device is one tap, where a re-asked
+ * congratulation on the device you already refused it on is the pressure this
+ * whole feature was permitted on condition of avoiding.
+ */
+export function GoalMilestonePrompt({
+  visible,
+  onConfirm,
+}: {
+  /** True only when the fitted trend has crossed the user's own goal AND the
+   *  milestone is not already on record. The caller owns both halves. */
+  visible: boolean;
+  onConfirm: () => void;
+}) {
+  const t = useT();
+  const styles = useThemedStyles(createStyles);
+  const [declined, decline] = useDismissedStub('milestones.goal.declined');
+
+  if (!visible || declined) return null;
+
+  return (
+    <Animated.View entering={enterUp(0)} style={styles.card} testID="goal-milestone-prompt">
+      <Text style={styles.title}>{t('milestones.goalAsk')}</Text>
+      <View style={styles.row}>
+        <PressScale
+          style={styles.primary}
+          testID="goal-milestone-add"
+          accessibilityRole="button"
+          onPress={() => {
+            haptics.tap();
+            onConfirm();
+          }}
+        >
+          <Text style={styles.primaryText}>{t('milestones.goalAdd')}</Text>
+        </PressScale>
+        <PressScale
+          style={styles.secondary}
+          testID="goal-milestone-decline"
+          accessibilityRole="button"
+          onPress={() => {
+            haptics.tap();
+            decline();
+          }}
+        >
+          <Text style={styles.secondaryText}>{t('milestones.goalDecline')}</Text>
+        </PressScale>
+      </View>
+    </Animated.View>
+  );
+}
+
+const createStyles = ({ colors }: Theme) =>
+  StyleSheet.create({
+    card: {
+      backgroundColor: colors.card,
+      borderRadius: radius.lg,
+      padding: space.lg,
+      gap: space.md,
+    },
+    // Manrope — never paired with `fontWeight` (ADR-0014).
+    title: { fontSize: font.body, fontFamily: type.heading, color: colors.ink, lineHeight: 24 },
+    row: { flexDirection: 'row', alignItems: 'center', gap: space.sm },
+    primary: {
+      backgroundColor: colors.ink,
+      borderRadius: radius.pill,
+      paddingHorizontal: space.lg,
+      paddingVertical: space.sm,
+    },
+    primaryText: { fontSize: font.small, color: colors.onInk, fontWeight: '700' },
+    secondary: { paddingHorizontal: space.md, paddingVertical: space.sm },
+    secondaryText: { fontSize: font.small, color: colors.muted },
+  });

--- a/apps/mobile/src/components/MilestoneNote.tsx
+++ b/apps/mobile/src/components/MilestoneNote.tsx
@@ -1,62 +1,155 @@
+import { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Animated from 'react-native-reanimated';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import type { MilestoneKey } from '@macrolog/core';
 import { type I18nKey, useT } from '@/i18n';
-import { enterUp } from '@/lib/motion';
-import { useThemedStyles, type Theme } from '@/lib/theme-context';
+import * as haptics from '@/lib/haptics';
+import { enterUp, PressScale } from '@/lib/motion';
+import { useTheme, useThemedStyles, type Theme } from '@/lib/theme-context';
 import { font, radius, space, type } from '@/theme';
+
+/** At most this many titles render; the rest are counted and live in the
+ *  archive. Sized from the real first-run case rather than a guess — see the
+ *  backfill note below. */
+const MAX_VISIBLE = 3;
+
+const DISMISS_KEY = 'milestones.note.dismissedDay';
+
+/**
+ * Remember that today's note was dismissed — and only today's.
+ *
+ * Stores the DAY KEY rather than a boolean, so the latch clears itself
+ * tomorrow. A permanent flag would silence every future milestone, and one
+ * key per dismissed day would accumulate forever; one key holding the last
+ * dismissed day does neither.
+ */
+function useDismissedForDay(dayKey: string): [boolean, () => void] {
+  const [day, setDay] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    void AsyncStorage.getItem(DISMISS_KEY)
+      .then((v) => {
+        if (alive) setDay(v);
+      })
+      // A cache that cannot be read is not an error worth surfacing: the note
+      // simply renders, which is a correct screen.
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setDay(dayKey);
+    // Fire and forget — the note is already gone on screen, and a failed write
+    // costs one dismissal, never a wrong render.
+    void AsyncStorage.setItem(DISMISS_KEY, dayKey).catch(() => {});
+  }, [dayKey]);
+
+  return [day === dayKey, dismiss];
+}
 
 /**
  * "Recorded today" — the one moment a milestone gets on Today.
  *
- * ## It is a STATE READOUT, not a Nudge, and that is load-bearing
+ * ## It is a state readout, not a Nudge — and being dismissable does not change that
  *
- * Today shows at most one Nudge, ever (`useTodayNudge`, UX_AUDIT §S14 TD1), and
- * the ranking exists so an update banner is never buried. This row sits outside
- * that queue — and it earns the exemption rather than taking it, by the same
- * test that exempts `OfflineBanner`: **it asks for nothing.** No button, no
- * dismiss control, nothing to resolve.
+ * Today shows at most one Nudge (`useTodayNudge`, UX_AUDIT §S14 TD1), and that
+ * ranking exists so an update banner is never buried. This row sits outside the
+ * queue, and the first version of it earned that by having no dismiss control at
+ * all. **That was the wrong reading of the rule.** `CONTEXT.md` defines a Nudge
+ * as a *promotional or optional prompt* — what's-new, refine, push-enable,
+ * install. A record of something you already did promotes nothing and asks for
+ * nothing; offering to clear it does not make it an advert. The Trends stub rows
+ * are the standing precedent: dismissable, and deliberately not Nudges.
  *
- * The dismissal question is answered by the clock instead. `useMilestones` only
- * reports keys whose `earnedAt` falls inside the current day, so the row expires
- * on its own at day end. A user who does not open the app that day never sees it
- * — which is correct for a record of something that already happened, and would
- * be wrong for a Nudge. That asymmetry is the proof the classification is honest
- * and not a loophole: had it needed a dismiss control it would belong in
- * `TodayNudge`'s union and be subject to the one-at-a-time rule.
+ * ## Why it needs the dismiss, which only a device showed
+ *
+ * **The first run backfills.** Every milestone an account has ever earned is
+ * recorded the day the feature arrives, so an existing user's first note is not
+ * one line — it is four, and for a hundred-day streak up to eight. The owner's
+ * own screenshot showed four stacked above the fold on Today, with no way to
+ * clear them for the rest of the day. A quiet record that occupies half the
+ * screen is neither quiet nor a record.
+ *
+ * So: at most {@link MAX_VISIBLE} titles, the remainder counted, the whole label
+ * tappable through to the archive, and an × that clears it for **today only**.
+ * Tomorrow's milestone gets its own note.
  *
  * ## Why there is no icon
  *
- * Typographic by decision (2026-08-29). A trophy glyph is the visual shorthand of
- * exactly the gamified trackers `README.md` defines this product against, and
- * the positioning word is *editorial*. The accent rule carries the emphasis; an
- * eyebrow carries the label. If it ever reads bare on a device, adding a glyph
- * is one line — removing one from a shipped design is not.
+ * Typographic by decision. A trophy glyph is the visual shorthand of exactly the
+ * gamified trackers `README.md` defines this product against. The accent rule
+ * carries the emphasis; the eyebrow carries the label.
  *
- * Title uses `type.heading` (Manrope) and therefore sets NO `fontWeight` —
+ * Titles use `type.heading` (Manrope) and therefore set NO `fontWeight` —
  * pairing the two is the ADR-0014 rule that silently renders the wrong face.
  */
-export function MilestoneNote({ keys }: { keys: readonly MilestoneKey[] }) {
+export function MilestoneNote({
+  keys,
+  dayKey,
+  onOpen,
+}: {
+  keys: readonly MilestoneKey[];
+  /** Today's day key under the user's boundary — scopes the dismissal. */
+  dayKey: string;
+  onOpen: () => void;
+}) {
   const t = useT();
   const styles = useThemedStyles(createStyles);
+  const { colors } = useTheme();
+  const [dismissed, dismiss] = useDismissedForDay(dayKey);
 
   // Almost every day. Rendering an empty shell would be a permanent fixture
   // announcing that nothing happened.
-  if (keys.length === 0) return null;
+  if (keys.length === 0 || dismissed) return null;
+
+  const shown = keys.slice(0, MAX_VISIBLE);
+  const extra = keys.length - shown.length;
 
   return (
     <Animated.View entering={enterUp(0)} style={styles.card} testID="milestone-note">
       <View style={styles.rule} />
-      <View style={styles.col}>
+      <PressScale
+        style={styles.body}
+        testID="milestone-note-open"
+        accessibilityRole="button"
+        accessibilityLabel={t('milestones.title')}
+        onPress={() => {
+          haptics.tap();
+          onOpen();
+        }}
+      >
         <Text style={styles.eyebrow}>{t('milestones.today')}</Text>
         {/* More than one can land on the same day — a first fast on the day a
-            streak ticks over. They stack rather than competing for one slot. */}
-        {keys.map((k) => (
+            streak ticks over, and on the first run, everything at once. */}
+        {shown.map((k) => (
           <Text key={k} style={styles.title}>
             {t(`milestones.${k}` as I18nKey)}
           </Text>
         ))}
-      </View>
+        {extra > 0 ? (
+          <Text style={styles.more}>{t('milestones.more', { n: String(extra) })}</Text>
+        ) : null}
+      </PressScale>
+      {/* Dismiss sits OUTSIDE the navigating pressable — nesting one touchable
+          in another makes which one fired depend on a few pixels, and these two
+          actions are opposites. Same shape as the Trends stub rows. */}
+      <PressScale
+        style={styles.dismiss}
+        testID="milestone-note-dismiss"
+        accessibilityRole="button"
+        accessibilityLabel={t('common.dismiss')}
+        onPress={() => {
+          haptics.tap();
+          dismiss();
+        }}
+      >
+        <Ionicons name="close" size={16} color={colors.faint} />
+      </PressScale>
     </Animated.View>
   );
 }
@@ -66,11 +159,9 @@ const createStyles = ({ colors }: Theme) =>
     card: {
       flexDirection: 'row',
       alignItems: 'stretch',
-      gap: space.md,
       backgroundColor: colors.card,
       borderRadius: radius.lg,
       paddingVertical: space.md,
-      paddingRight: space.lg,
       overflow: 'hidden',
     },
     // The whole visual accent: a hairline rule, not a badge. `alignSelf:
@@ -83,7 +174,10 @@ const createStyles = ({ colors }: Theme) =>
       borderTopRightRadius: radius.sm,
       borderBottomRightRadius: radius.sm,
     },
-    col: { flex: 1, gap: 2, paddingLeft: space.sm },
+    // `flex: 1` so the dismiss stays inside the card's padding rather than
+    // being shoved against the edge by the label's intrinsic width — the
+    // device-only bug the Trends stub row already hit once.
+    body: { flex: 1, gap: 2, paddingLeft: space.md, paddingRight: space.sm },
     eyebrow: {
       fontSize: font.tiny,
       letterSpacing: 0.8,
@@ -93,4 +187,7 @@ const createStyles = ({ colors }: Theme) =>
     },
     // Manrope — no `fontWeight` here on purpose (ADR-0014).
     title: { fontSize: font.body, fontFamily: type.heading, color: colors.ink },
+    more: { fontSize: font.small, color: colors.muted, marginTop: 2 },
+    // Generous padding, small glyph — a one-way action beside a navigating one.
+    dismiss: { paddingLeft: space.sm, paddingRight: space.md, paddingVertical: space.xs },
   });

--- a/apps/mobile/src/hooks/useBody.ts
+++ b/apps/mobile/src/hooks/useBody.ts
@@ -17,6 +17,7 @@ import {
   dayKeyAt,
   latestNavyBodyFat,
   missingBodyFatInputs,
+  goalTrendCrossed,
   projectWeight,
   weightPointsForDays,
   weightSeriesForDays,
@@ -66,6 +67,11 @@ export interface BodyState {
   /** Linear-fit weight trend + projected goal date, or null when there
    *  aren't enough weigh-ins to fit a line. */
   projection: WeightProjection | null;
+  /** Whether the fitted trend has crossed the user's own goal weight — the
+   *  OBJECTIVE half only (`goalTrendCrossed`, never `goalReached`). What the
+   *  `goal-reached` milestone prompt asks a question with; the person answering
+   *  supplies the provenance the schema cannot (#110). */
+  goalCrossed: boolean;
   /** Last 14 days of daily weights (oldest → newest) for the sparkline. */
   weightSeries: number[];
   /** 7-day dashed forecast stepping from the last weight along the fitted
@@ -144,6 +150,27 @@ export function useBody(): BodyState {
     return projectWeight(points, profile?.targetWeightLbs ?? profile?.goalWeightLbs ?? null);
   }, [weights, profile]);
 
+  /**
+   * Has the weight TREND crossed the goal the user set for themselves?
+   *
+   * Only the objective half (`goalTrendCrossed`, not `goalReached`). It is what
+   * the Body prompt asks a question with — `dailyWeights` carries no `source`,
+   * so nothing here can tell a hand-typed weigh-in from an auto-imported one,
+   * and the person answering the prompt IS the provenance (#110).
+   *
+   * Reads the same fitted trend the Body hero already shows, over the same
+   * 28-day window, so the prompt cannot disagree with the number above it.
+   */
+  const goalCrossed = useMemo<boolean>(() => {
+    const points = weightPointsForDays(weights, PROJECTION_WINDOW_DAYS, new Date());
+    return goalTrendCrossed({
+      goalDirection: profile?.goalDirection,
+      targetWeightLbs: profile?.targetWeightLbs ?? profile?.goalWeightLbs ?? null,
+      trendWeightLb: projection?.currentFittedLb ?? null,
+      readingCount: points.length,
+    });
+  }, [weights, profile, projection]);
+
   // 14-day weight line (oldest → newest), missed days dropped.
   const weightSeries = useMemo<number[]>(
     () => weightSeriesForDays(weights, SPARK_DAYS, new Date()),
@@ -218,6 +245,7 @@ export function useBody(): BodyState {
     updateMeasurement,
     deleteMeasurement,
     projection,
+    goalCrossed,
     weightSeries,
     projectedSeries,
     goalProgress: computeGoalProgress(logs, weights, profile?.targetWeightLbs ?? profile?.goalWeightLbs ?? null),

--- a/apps/mobile/src/i18n/en.ts
+++ b/apps/mobile/src/i18n/en.ts
@@ -1328,6 +1328,14 @@ export const en = {
   'milestones.first-weigh-in': 'First weigh-in',
   'milestones.first-fast': 'First fast recorded',
   'milestones.first-workout': 'First workout finished',
+  'milestones.goal-reached': 'Reached your goal weight',
+  // The #110 confirmation. A QUESTION, never a celebration — it names no
+  // number and congratulates nothing until the user answers. Weight-magnitude
+  // praise is the half #110 dropped `first-5-lb` to avoid.
+  'milestones.more': '+{n} more',
+  'milestones.goalAsk': 'Your weight trend has reached the goal you set. Add it to your milestones?',
+  'milestones.goalAdd': 'Add it',
+  'milestones.goalDecline': 'Not now',
 } as const;
 
 export type I18nKey = keyof typeof en;

--- a/apps/mobile/src/i18n/es-PR.ts
+++ b/apps/mobile/src/i18n/es-PR.ts
@@ -1232,4 +1232,9 @@ export const esPR: Record<I18nKey, string> = {
   'milestones.first-weigh-in': 'Primer pesaje',
   'milestones.first-fast': 'Primer ayuno registrado',
   'milestones.first-workout': 'Primer entrenamiento completado',
+  'milestones.goal-reached': 'Llegaste a tu peso meta',
+  'milestones.more': '+{n} más',
+  'milestones.goalAsk': 'Tu tendencia de peso llegó a la meta que pusiste. ¿La añades a tus hitos?',
+  'milestones.goalAdd': 'Añadir',
+  'milestones.goalDecline': 'Ahora no',
 };

--- a/apps/mobile/src/i18n/pt-BR.ts
+++ b/apps/mobile/src/i18n/pt-BR.ts
@@ -1212,4 +1212,9 @@ export const ptBR = {
   'milestones.first-weigh-in': 'Primeira pesagem',
   'milestones.first-fast': 'Primeiro jejum registrado',
   'milestones.first-workout': 'Primeiro treino concluído',
+  'milestones.goal-reached': 'Chegou ao seu peso meta',
+  'milestones.more': '+{n} mais',
+  'milestones.goalAsk': 'Sua tendência de peso chegou à meta que você definiu. Adicionar aos seus marcos?',
+  'milestones.goalAdd': 'Adicionar',
+  'milestones.goalDecline': 'Agora não',
 } as const;

--- a/packages/core/src/milestones.test.ts
+++ b/packages/core/src/milestones.test.ts
@@ -4,6 +4,7 @@ import {
   GOAL_MIN_READINGS,
   MILESTONE_ORDER,
   goalReached,
+  goalTrendCrossed,
   newlyEarned,
   sortMilestones,
   streakMilestonesReached,
@@ -94,6 +95,42 @@ describe('goalReached', () => {
 
   it('will not record on a trend the user never contributed to', () => {
     expect(goalReached({ ...sound, manualReadingCount: 0 })).toBe(false);
+  });
+
+  // ── The split, and why it must not collapse ──────────────────────────
+  //
+  // `goalTrendCrossed` is the objective fact a UI may ASK a question about.
+  // `goalReached` additionally demands that the person put the numbers there,
+  // which today's schema cannot show — `dailyWeights` carries no `source`. The
+  // confirmation prompt on Body supplies the human instead. If these two ever
+  // collapse into one, an automatic writer inherits the loose test.
+
+  it('goalTrendCrossed ignores provenance — it is the objective fact', () => {
+    expect(goalTrendCrossed({ ...sound, manualReadingCount: 0 })).toBe(true);
+  });
+
+  it('goalTrendCrossed still refuses everything else goalReached refuses', () => {
+    expect(goalTrendCrossed({ ...sound, goalDirection: 'maintain' })).toBe(false);
+    expect(goalTrendCrossed({ ...sound, goalDirection: 'gain' })).toBe(false);
+    expect(goalTrendCrossed({ ...sound, readingCount: GOAL_MIN_READINGS - 1 })).toBe(false);
+    expect(goalTrendCrossed({ ...sound, targetWeightLbs: null })).toBe(false);
+    expect(goalTrendCrossed({ ...sound, trendWeightLb: null })).toBe(false);
+  });
+
+  it('goalReached is strictly stronger than goalTrendCrossed', () => {
+    // Anything goalReached accepts, goalTrendCrossed must accept too. A future
+    // edit that made the strict one pass where the loose one fails would mean
+    // the provenance guard had stopped guarding anything.
+    const cases: GoalEvidence[] = [
+      sound,
+      { ...sound, goalDirection: 'gain', trendWeightLb: 181 },
+      { ...sound, trendWeightLb: 180 },
+      { ...sound, manualReadingCount: 0 },
+      { ...sound, goalDirection: 'maintain' },
+    ];
+    for (const c of cases) {
+      if (goalReached(c)) expect(goalTrendCrossed(c)).toBe(true);
+    }
   });
 
   it('refuses absent numbers rather than coercing them', () => {

--- a/packages/core/src/milestones.ts
+++ b/packages/core/src/milestones.ts
@@ -144,7 +144,7 @@ export interface GoalEvidence {
  * directions are asserted in the tests, because a mis-fire here is silent in
  * BOTH — a wrongly-withheld award looks identical to a user who has not arrived.
  */
-export function goalReached(ev: GoalEvidence): boolean {
+export function goalTrendCrossed(ev: GoalEvidence): boolean {
   const { goalDirection, targetWeightLbs, trendWeightLb } = ev;
 
   // Maintain has no line to cross, and an absent direction is not a licence to
@@ -156,12 +156,31 @@ export function goalReached(ev: GoalEvidence): boolean {
   const readings = ev.readingCount ?? 0;
   if (readings < GOAL_MIN_READINGS) return false;
 
-  const manual = ev.manualReadingCount ?? 0;
-  if (manual < 1) return false;
-
   return goalDirection === 'lose'
     ? trendWeightLb <= targetWeightLbs
     : trendWeightLb >= targetWeightLbs;
+}
+
+/**
+ * The same fact, plus evidence that the person put the numbers there.
+ *
+ * ## Why this is separate from {@link goalTrendCrossed}, and must stay separate
+ *
+ * `users/{uid}/dailyWeights/{dateKey}` is `{ weight }` with **no `source`** — a
+ * hand-typed weigh-in and one auto-imported from Apple Health or Health Connect
+ * are byte-identical documents. So on today's schema this predicate cannot be
+ * satisfied by an app that imports weight, and that is the correct outcome
+ * rather than a bug to route around: `useHealthAutoImport` re-imports on every
+ * foreground, and one stray 158 lb reading has already moved this project's
+ * measured maintenance from 2,741 to 1,619 kcal.
+ *
+ * **`goalTrendCrossed` is therefore what a UI asks a question with, and this is
+ * what an automatic writer would have to satisfy.** The split exists so that a
+ * later automatic path cannot quietly acquire the loose test: anything awarding
+ * `goal-reached` without a human in the loop must call THIS one.
+ */
+export function goalReached(ev: GoalEvidence): boolean {
+  return goalTrendCrossed(ev) && (ev.manualReadingCount ?? 0) >= 1;
 }
 
 /**


### PR DESCRIPTION
feat(milestones): goal-reached, behind the human the schema cannot supply (#110)

Closes the last milestone category, and the Today note becomes dismissable.

## goal-reached

`users/{uid}/dailyWeights/{dateKey}` is `{ weight }` with NO `source`, so a
hand-typed weigh-in and one auto-imported from Apple Health or Health Connect
are byte-identical. `goalReached()` demands manual provenance and today's schema
cannot show it — and the guard is not negotiable: `useHealthAutoImport`
re-imports on every foreground, and one stray 158 lb reading has already moved
this project's measured maintenance from 2,741 to 1,619 kcal.

REJECTED: adding `source` to `dailyWeights`. That is a `firestore.rules` change
on a collection the FROZEN web app also writes, and `hasOnly` validates the
merged document — get it wrong and the web's weigh-ins start failing. A
cross-frontend rules deploy under a freeze, for one milestone.

SHIPPED: the person answers. `goalTrendCrossed()` is split out as the objective
half (direction, target, fitted trend, >= 5 readings) and is what the Body
prompt asks a question with; `goalReached()` keeps the provenance requirement so
that any FUTURE automatic writer cannot quietly inherit the loose test. A test
asserts `goalReached` stays strictly stronger than `goalTrendCrossed`.

The prompt is a QUESTION, never a celebration. Tests assert — in all three
locales — that it contains no digit, no weight unit, no congratulation, and that
it still ends in a question mark. Weight-magnitude praise is exactly what #110
dropped `first-5-lb` and `four-weeks-on-target` to avoid, and copy is where it
would creep back.

Declining is remembered per device; accepting writes the milestone, which then
filters everywhere via `newlyEarned`. A "yes" syncs and a "no" does not, which
is the right way round.

## The Today note is now dismissable — from the owner's screenshot

THE FIRST RUN BACKFILLS. Every milestone an account has ever earned is recorded
the day the feature arrives, so an existing user's first note is not one line:
the owner's own iPhone showed FOUR stacked above the fold, and a hundred-day
streak would show eight. There was no way to clear it for the rest of the day.

I had made it non-dismissable on purpose, to keep it a state readout outside the
one-Nudge queue. **That was the wrong reading of the rule.** `CONTEXT.md` defines
a Nudge as a *promotional or optional prompt*; a record of something you already
did promotes nothing, and offering to clear it does not make it an advert. The
Trends stub rows are the standing precedent — dismissable, and not Nudges.

So: at most 3 titles with the remainder counted, the label tappable through to
the archive, and an X that clears it for TODAY ONLY (the day key is stored, not
a boolean, so tomorrow's milestone still gets its note and one key never
becomes one-per-day-forever).

Two test-harness facts re-learned and written down: the mocked AsyncStorage
persists across tests in a file, so one dismiss silently hid the row in the
next; and under React 19 a press's state update is not committed when
`fireEvent.press` returns, so the assertion needs `waitFor`.

core 1414 -> 1417, mobile 594 -> 606, tsc clean.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LvHL8Wiut8oPKARUGtKsYg
